### PR TITLE
feat: add descriptions below titles for tabs and filters

### DIFF
--- a/app/features/filters.py
+++ b/app/features/filters.py
@@ -299,6 +299,11 @@ layout = (
                     "marginBottom": "10px",
                 },
             ),
+            html.P(
+                "Use the controls below to narrow down the resolutions by keyword, country, year range, or subject area. "
+                "Select a main country to enable voting agreement analysis across the tabs.",
+                style={"color": "#7f8c8d", "marginBottom": "20px"}
+            ),
             # Filters container
             html.Div(
                 [

--- a/app/pages/trends_page.py
+++ b/app/pages/trends_page.py
@@ -56,6 +56,11 @@ def layout(countr1_alpha3: str | None = None, **other_keyword_arguments):
                             html.Div(
                                 [
                                     html.H2("Preview of resolutions"),
+                                    html.P(
+                                        "Browse all UN General Assembly resolutions matching the current filters. "
+                                        "Use the sort and search controls below to explore the list, and click any resolution to view its full details.",
+                                        style={"color": "#7f8c8d", "marginBottom": "20px"}
+                                    ),
                                     *resolution_list.layout,
                                 ],
                                 className="tab-content",
@@ -109,6 +114,11 @@ def layout(countr1_alpha3: str | None = None, **other_keyword_arguments):
                             html.Div(
                                 [
                                     html.H2("Resolution Title Word Cloud"),
+                                    html.P(
+                                        "Visualises the most frequent words appearing in UN resolution titles for the selected filters. "
+                                        "Larger words appear more often. Hover over a word to see how many resolutions contain it.",
+                                        style={"color": "#7f8c8d", "marginBottom": "20px"}
+                                    ),
                                     *wordcloud_interactive.layout,
                                 ],
                                 className="tab-content",


### PR DESCRIPTION
## Summary
- Added explanatory paragraph below the **Resolutions** tab title
- Added explanatory paragraph below the **Word Cloud** tab title
- Added explanatory paragraph below the **Filter the Data** section header

All descriptions follow the existing pattern used in the Agreement by Subject tab (gray text, `#7f8c8d`, 20px bottom margin).

## Test plan
- [ ] Navigate to the Trends page
- [ ] Check the Resolutions tab shows a description below the title
- [ ] Check the Word Cloud tab shows a description below the title
- [ ] Check the Filter the Data section shows a description below the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)