### PR TITLE
feat: resolve historical UN member state names in country dropdown

### DIFF
--- a/app/assets/successor_states.csv
+++ b/app/assets/successor_states.csv
@@ -249,3 +249,7 @@ M07,I07,fs,Zanzibar,1963-12-16,1964-04-26,"Following the ratification on 26 Apr.
 890,YUG,fs,Yugoslavia,1992-04-27,2003-02-03,Used for both pre-1992 six-member Socialist Federal Republic of Yugoslavia and succeeding two-member Federal Republic of Yugoslavia (27 Apr. 1992-3 Feb. 2003); the latter changed its name to Serbia and Montenegro as of 4 Feb. 2003,Yugoslavia
 894,ZMB,ms,Zambia,1964-12-01,,,Zambia
 716,ZWE,ms,Zimbabwe,1980-08-25,,,Zimbabwe
+834,EAT,fs,Tanganyika,1961-12-14,1964-04-25,Tanganyika joined the UN on 14 Dec. 1961; merged with Zanzibar on 26 Apr. 1964 to form the United Republic of Tanganyika and Zanzibar (later Tanzania),United Republic of Tanzania
+834,EAZ,fs,Zanzibar,1963-12-16,1964-04-25,Zanzibar joined the UN on 16 Dec. 1963; merged with Tanganyika on 26 Apr. 1964 to form the United Republic of Tanganyika and Zanzibar (later Tanzania),United Republic of Tanzania
+891,SCG,fs,Serbia and Montenegro,2003-02-04,2006-06-02,Federal Republic of Yugoslavia changed its name to Serbia and Montenegro on 4 Feb. 2003; Montenegro declared independence 3 June 2006; Serbia proclaimed independence 5 June 2006,Serbia
+280,GER,fs,Germany Federal Republic of,1973-09-18,1990-10-02,West Germany used code GER in UN voting records; became unified Germany (DEU) on 3 Oct. 1990,Germany

--- a/app/assets/successor_states.csv
+++ b/app/assets/successor_states.csv
@@ -88,7 +88,7 @@
 266,GAB,ms,Gabon,1960-09-20,,,Gabon
 270,GMB,ms,Gambia,1965-09-21,,"From 24 Feb. 2016 - 15 Feb. 2017, formal name Islamic Republic of The Gambia. From 16 Feb. 2017, formal name Republic of The Gambia.",Gambia
 268,GEO,ms,Georgia,1992-07-31,,,Georgia
-278,DDR,fs,German Democratic Republic,1973-09-18,1990-10-02,On 3 Oct. 1990 the German Democratic Republic and the Federal Republic of Germany united to form one sovereign nation called the 'Federal Republic of Germany' (short form 'Germany'),Germany
+278,DDR,fs,German Democratic Republic (DDR),1973-09-18,1990-10-02,On 3 Oct. 1990 the German Democratic Republic and the Federal Republic of Germany united to form one sovereign nation called the 'Federal Republic of Germany' (short form 'Germany'),Germany
 280,DEU,fs,"Germany, Federal Republic of",1973-09-18,1990-10-02,On 3 Oct. 1990 the German Democratic Republic and the Federal Republic of Germany united to form one sovereign nation called the 'Federal Republic of Germany' (short form 'Germany'),Germany
 276,DEU,ms,Germany,1990-10-03,,On 3 Oct. 1990 the German Democratic Republic and the Federal Republic of Germany united to form one sovereign nation called the 'Federal Republic of Germany',Germany
 288,GHA,ms,Ghana,1957-03-08,,,Ghana
@@ -252,4 +252,4 @@ M07,I07,fs,Zanzibar,1963-12-16,1964-04-26,"Following the ratification on 26 Apr.
 834,EAT,fs,Tanganyika,1961-12-14,1964-04-25,Tanganyika joined the UN on 14 Dec. 1961; merged with Zanzibar on 26 Apr. 1964 to form the United Republic of Tanganyika and Zanzibar (later Tanzania),United Republic of Tanzania
 834,EAZ,fs,Zanzibar,1963-12-16,1964-04-25,Zanzibar joined the UN on 16 Dec. 1963; merged with Tanganyika on 26 Apr. 1964 to form the United Republic of Tanganyika and Zanzibar (later Tanzania),United Republic of Tanzania
 891,SCG,fs,Serbia and Montenegro,2003-02-04,2006-06-02,Federal Republic of Yugoslavia changed its name to Serbia and Montenegro on 4 Feb. 2003; Montenegro declared independence 3 June 2006; Serbia proclaimed independence 5 June 2006,Serbia
-280,GER,fs,Germany Federal Republic of,1973-09-18,1990-10-02,West Germany used code GER in UN voting records; became unified Germany (DEU) on 3 Oct. 1990,Germany
+280,GER,fs,Germany Federal Republic of (BRD),1973-09-18,1990-10-02,West Germany used code GER in UN voting records; became unified Germany (DEU) on 3 Oct. 1990,Germany

--- a/app/assets/successor_states.csv
+++ b/app/assets/successor_states.csv
@@ -1,0 +1,251 @@
+﻿M49_code,ms_code,status,ms_name,start_date,end_date,note,search_key
+004,AFG,ms,Afghanistan,1946-09-11,,"Per UNTERM, formal name (or long form) ""Islamic Republic of Afghanistan"" adopted Nov. 2004; preceding that, formal name had been ""Transitional Islamic State of Afghanistan""",Afghanistan
+008,ALB,ms,Albania,1955-12-14,,,Albania
+012,DZA,ms,Algeria,1962-08-10,,,Algeria
+020,AND,ms,Andorra,1993-07-28,,,Andorra
+024,AGO,ms,Angola,1976-12-01,,,Angola
+028,ATG,ms,Antigua and Barbuda,1981-11-11,,,Antigua and Barbuda
+032,ARG,ms,Argentina,1945-10-24,,,Argentina
+051,ARM,ms,Armenia,1992-03-02,,,Armenia
+036,AUS,ms,Australia,1945-10-24,,,Australia
+040,AUT,ms,Austria,1955-12-14,,,Austria
+031,AZE,ms,Azerbaijan,1992-03-02,,,Azerbaijan
+044,BHS,ms,Bahamas,1973-09-18,,,Bahamas
+048,BHR,ms,Bahrain,1971-09-21,,,Bahrain
+050,BGD,ms,Bangladesh,1974-09-17,,,Bangladesh
+052,BRB,ms,Barbados,1966-09-12,,,Barbados
+112,BLR,fs,Byelorussian SSR,1945-10-24,1991-09-18,Name changed from 'Byelorussian SSR' to 'Belarus' effective 19 Sept. 1991,Belarus
+112,BLR,ms,Belarus,1991-09-19,,,Belarus
+056,BEL,ms,Belgium,1945-10-24,,,Belgium
+084,BLZ,ms,Belize,1981-09-25,,,Belize
+204,BEN,fs,Dahomey,1960-09-20,1975-12-01,Name changed to Benin on 2 Dec. 1975,Benin
+204,BEN,ms,Benin,1975-12-02,,,Benin
+064,BTN,ms,Bhutan,1971-09-21,,,Bhutan
+068,BOL,fs,Bolivia,1945-10-24,2009-04-06,Formal name changed from 'Bolivia' to 'Plurinational State of Bolivia' in accordance with 2009 constitutional decree on 7 Apr. 2009,Bolivia (Plurinational State of)
+068,BOL,ms,Bolivia (Plurinational State of),2009-04-07,,Permanent Mission specified that short form of name is Bolivia (Plurinational State of),Bolivia (Plurinational State of)
+070,BIH,ms,Bosnia and Herzegovina,1992-05-22,,,Bosnia and Herzegovina
+072,BWA,ms,Botswana,1966-10-17,,,Botswana
+076,BRA,ms,Brazil,1945-10-24,,,Brazil
+096,BRN,ms,Brunei Darussalam,1984-09-21,,,Brunei Darussalam
+100,BGR,ms,Bulgaria,1955-12-14,,,Bulgaria
+854,HVO,fs,Upper Volta,1960-09-20,1984-08-03,Name changed to 'Burkina Faso' on 4 Aug. 1984,Burkina Faso
+854,BFA,ms,Burkina Faso,1984-08-04,,,Burkina Faso
+108,BDI,ms,Burundi,1962-09-18,,,Burundi
+132,CPV,fs,Cape Verde,1975-09-16,2013-10-23,Name changed to 'Cabo Verde' on 24 Oct. 2013,Cabo Verde
+132,CPV,ms,Cabo Verde,2013-10-24,,,Cabo Verde
+116,KHM,ms,Cambodia,1955-12-14,1970-12-28,"Name reverted to Cambodia on 3 Feb. 1990, formerly, as follows: as from 6 Apr. 1976 to 3 Feb. 1990 'Democratic Kampuchea'; as from 30 Apr. 1975 to 6 Apr. 1976 'Cambodia'; as from 28 Dec. 1970 to 30 Apr. 1975 'Khmer Republic'",Cambodia
+116,KHM,fs,Khmer Republic,1970-12-29,1975-04-29,,Cambodia
+116,KHM,ms,Cambodia,1975-04-30,1976-04-06,"Name reverted to Cambodia on 3 Feb. 1990, formerly, as follows: as from 6 Apr. 1976 to 3 Feb. 1990 'Democratic Kampuchea'; as from 30 Apr. 1975 to 6 Apr. 1976 'Cambodia'; as from 28 Dec. 1970 to 30 Apr. 1975 'Khmer Republic'",Cambodia
+116,KHM,fs,Democratic Kampuchea,1976-04-06,1990-02-02,Name reverted to Cambodia as of 3 Feb. 1990,Cambodia
+116,KHM,ms,Cambodia,1990-02-03,,"Name reverted to Cambodia on 3 Feb. 1990, formerly, as follows: as from 6 Apr. 1976 to 3 Feb. 1990 'Democratic Kampuchea'; as from 30 Apr. 1975 to 6 Apr. 1976 'Cambodia'; as from 28 Dec. 1970 to 30 Apr. 1975 'Khmer Republic'",Cambodia
+120,CMR,ms,Cameroon,1960-09-20,1975-03-09,,Cameroon
+120,CMR,fs,United Republic of Cameroon,1975-03-10,1975-02-03,,Cameroon
+120,CMR,ms,Cameroon,1984-02-04,,,Cameroon
+124,CAN,ms,Canada,1945-10-24,,,Canada
+140,CAF,ms,Central African Republic,1960-09-20,1976-12-19,,Central African Republic
+140,CAF,fs,Central African Empire,1976-12-20,1979-09-19,The 'Central African Republic' was constituted into the 'Central African Empire' from 20 Dec. 1976 to 20 Sept. 1979,Central African Republic
+140,CAF,ms,Central African Republic,1979-09-20,,,Central African Republic
+148,TCD,ms,Chad,1960-09-20,,,Chad
+152,CHL,ms,Chile,1945-10-24,,,Chile
+156,CHN,ms,China,1945-10-24,,,China
+170,COL,ms,Colombia,1945-10-24,,,Colombia
+174,COM,ms,Comoros,1975-12-11,,,Comoros
+178,COG,fs,Republic of the Congo (Brazzaville),1960-09-20,1969-12-31,,Congo
+178,COG,fs,People's Republic of the Congo,1970-01-01,1971-11-14,"In a communication dated 15 Nov. 1971, the Permanent Mission of the People's Republic of the Congo informed the Secretary-General that their country would henceforth be known as the 'Congo'",Congo
+178,COG,ms,Congo,1971-11-15,,,Congo
+188,CRI,ms,Costa Rica,1945-10-24,,,Costa Rica
+384,CIV,fs,Ivory Coast,1960-09-20,1985-12-31,,Côte d'Ivoire
+384,CIV,ms,Côte d'Ivoire,1986-01-01,,,Côte d'Ivoire
+191,HRV,ms,Croatia,1992-05-22,,,Croatia
+192,CUB,ms,Cuba,1945-10-24,,,Cuba
+196,CYP,ms,Cyprus,1960-09-20,,,Cyprus
+203,CZE,fs,Czech Republic,1993-01-01,2016-05-16,,Czechia
+203,CZE,ms,Czechia,2016-05-17,,"Short name changed to 'Czechia' on 17 May 2016, formal name remains 'Czech Republic'",Czechia
+200,CSK,fs,Czechoslovakia,1945-10-24,1992-12-31,,Czechoslovakia
+408,PRK,ms,Democratic People's Republic of Korea,1991-09-17,,,Democratic People's Republic of Korea
+180,COD,fs,Republic of the Congo (Leopoldville),1960-06-30,1964-07-30,Name changed from 'Republic of the Congo (Leopoldville)' to 'Democratic Republic of the Congo' on 1 Aug. 1964 (Luluabourg Constitution). Name changed to 'Zaire' on 27 Oct. 1971 and changed back to 'Democratic Republic of the Congo' on 17 May 1997.,Democratic Republic of the Congo
+180,COD,ms,Democratic Republic of the Congo,1964-08-01,1971-10-26,,Democratic Republic of the Congo
+180,ZAR,fs,Zaïre,1971-10-27,1997-05-16,Name changed from 'Republic of the Congo (Leopoldville)' to 'Democratic Republic of the Congo' on 1 Aug. 1964 (Luluabourg Constitution). Name changed to 'Zaire' on 27 Oct. 1971 and changed back to 'Democratic Republic of the Congo' on 17 May 1997.,Democratic Republic of the Congo
+180,COD,ms,Democratic Republic of the Congo,1997-05-17,,,Democratic Republic of the Congo
+720,YMD,fs,Democratic Yemen,1970-11-30,1990-05-21,On 22 May 1990 Democratic Yemen merged with the Yemen Arab Republic to form the Republic of Yemen (Yemen).,Democratic Yemen
+208,DNK,ms,Denmark,1945-10-24,,,Denmark
+262,DJI,ms,Djibouti,1977-09-20,,,Djibouti
+212,DMA,ms,Dominica,1978-12-18,,,Dominica
+214,DOM,ms,Dominican Republic,1945-10-24,,,Dominican Republic
+218,ECU,ms,Ecuador,1945-10-24,,,Ecuador
+818,EGY,ms,Egypt,1945-10-24,1958-02-21,Egypt and Syria united to form the United Arab Republic from 22 Feb. 1958 to 27 Sept. 1961. Egypt retained the name United Arab Republic as its own official designation until 2 Sept. 1971.,Egypt
+818,EGY,ms,Egypt,1971-09-02,,Egypt and Syria united to form the United Arab Republic from 22 Feb. 1958 to 27 Sept. 1961. Egypt retained the name United Arab Republic as its own official designation until 2 Sept. 1971.,Egypt
+222,SLV,ms,El Salvador,1945-10-24,,,El Salvador
+226,GNQ,ms,Equatorial Guinea,1968-12-11,,,Equatorial Guinea
+232,ERI,ms,Eritrea,1993-05-28,,,Eritrea
+233,EST,ms,Estonia,1991-09-17,,,Estonia
+748,SWZ,fs,Swaziland,1968-09-24,2018-04-18,,Eswatini
+748,SWZ,ms,Eswatini,2018-04-19,,,Eswatini
+231,ETH,ms,Ethiopia,1945-10-24,,,Ethiopia
+242,FJI,ms,Fiji,1970-10-13,,,Fiji
+246,FIN,ms,Finland,1955-12-14,,,Finland
+250,FRA,ms,France,1945-10-24,,,France
+266,GAB,ms,Gabon,1960-09-20,,,Gabon
+270,GMB,ms,Gambia,1965-09-21,,"From 24 Feb. 2016 - 15 Feb. 2017, formal name Islamic Republic of The Gambia. From 16 Feb. 2017, formal name Republic of The Gambia.",Gambia
+268,GEO,ms,Georgia,1992-07-31,,,Georgia
+278,DDR,fs,German Democratic Republic,1973-09-18,1990-10-02,On 3 Oct. 1990 the German Democratic Republic and the Federal Republic of Germany united to form one sovereign nation called the 'Federal Republic of Germany' (short form 'Germany'),Germany
+280,DEU,fs,"Germany, Federal Republic of",1973-09-18,1990-10-02,On 3 Oct. 1990 the German Democratic Republic and the Federal Republic of Germany united to form one sovereign nation called the 'Federal Republic of Germany' (short form 'Germany'),Germany
+276,DEU,ms,Germany,1990-10-03,,On 3 Oct. 1990 the German Democratic Republic and the Federal Republic of Germany united to form one sovereign nation called the 'Federal Republic of Germany',Germany
+288,GHA,ms,Ghana,1957-03-08,,,Ghana
+300,GRC,ms,Greece,1945-10-24,,,Greece
+308,GRD,ms,Grenada,1974-09-17,,,Grenada
+320,GTM,ms,Guatemala,1945-10-24,,,Guatemala
+324,GIN,ms,Guinea,1958-12-12,,,Guinea
+624,GNB,ms,Guinea-Bissau,1974-09-17,,,Guinea-Bissau
+328,GUY,ms,Guyana,1966-09-20,,,Guyana
+332,HTI,ms,Haiti,1945-10-24,,,Haiti
+340,HND,ms,Honduras,1945-10-24,,,Honduras
+348,HUN,ms,Hungary,1955-12-14,,,Hungary
+352,ISL,ms,Iceland,1946-11-19,,,Iceland
+356,IND,ms,India,1945-10-24,,,India
+360,IDN,ms,Indonesia,1950-09-28,,,Indonesia
+364,IRN,fs,Iran,1945-10-24,1982-11-03,"On 4 Nov. 1982, the Government of the Islamic Republic of Iran notified the Secretary-General that the designation 'Iran (Islamic Republic of)' should be used.",Iran (Islamic Republic of)
+364,IRN,ms,Iran (Islamic Republic of),1982-11-04,,,Iran (Islamic Republic of)
+368,IRQ,ms,Iraq,1945-10-24,,,Iraq
+372,IRL,ms,Ireland,1955-12-14,,,Ireland
+376,ISR,ms,Israel,1949-11-05,,,Israel
+380,ITA,ms,Italy,1955-12-14,,,Italy
+388,JAM,ms,Jamaica,1962-09-18,,,Jamaica
+392,JPN,ms,Japan,1956-12-18,,,Japan
+400,JOR,ms,Jordan,1955-12-14,,,Jordan
+398,KAZ,ms,Kazakhstan,1992-03-02,,"Spelling ""Kazakstan"" adopted by UN 8 May 1995 at country's request. Spelling reverted to ""Kazakhstan"" effective 20 June 1997",Kazakhstan
+404,KEN,ms,Kenya,1963-12-16,,,Kenya
+296,KIR,ms,Kiribati,1999-09-14,,,Kiribati
+414,KWT,ms,Kuwait,1963-05-14,,,Kuwait
+417,KGZ,ms,Kyrgyzstan,1992-03-02,,,Kyrgyzstan
+418,LAO,fs,Laos,1955-12-14,1975-12-22,Formerly 'Laos' until 22 Dec. 1975,Lao People's Democratic Republic
+418,LAO,ms,Lao People's Democratic Republic,1975-12-23,,,Lao People's Democratic Republic
+428,LVA,ms,Latvia,1991-09-17,,,Latvia
+422,LBN,ms,Lebanon,1945-10-24,,,Lebanon
+426,LSO,ms,Lesotho,1966-10-17,,,Lesotho
+430,LBR,ms,Liberia,1945-10-24,,,Liberia
+434,LBY,fs,Kingdom of Libya,1955-12-14,1969-08-31,The Libyan Arab Republic was proclaimed on 1 Sept. 1969,Libya
+434,LBY,fs,Libyan Arab Republic,1969-09-01,1977-03-31,,Libya
+434,LBY,fs,Libyan Arab Jamahiriya,1977-04-01,2011-09-15,,Libya
+434,LBY,ms,Libya,2011-09-16,,"By a communication of 22 Dec. 2017, the Permanent Mission informed the UN of a change of the official name to State of Libya; short name: Libya.",Libya
+438,LIE,ms,Liechtenstein,1990-09-18,,,Liechtenstein
+440,LTU,ms,Lithuania,1991-09-17,,,Lithuania
+442,LUX,ms,Luxembourg,1945-10-24,,,Luxembourg
+450,MDG,ms,Madagascar,1960-09-20,,,Madagascar
+454,MWI,ms,Malawi,1964-12-01,,,Malawi
+458,MYS,fs,Federation of Malaya,1957-09-17,1963-09-15,"On 16 Sept. 1963, the 'Federation of Malaya' changed its name to 'Malaysia'",Malaysia
+458,MYS,ms,Malaysia,1963-09-16,,,Malaysia
+462,MDV,ms,Maldives,1969-04-14,,"In a letter dated 14 April 1969, the Permanent Representative informed the Secretary-General that the country be known as 'Maldives' instead of 'Maldive Islands', and that the full title of the State be 'Republic of Maldives'",Maldives
+466,MLI,ms,Mali,1960-09-28,,,Mali
+470,MLT,ms,Malta,1964-01-12,,,Malta
+584,MHL,ms,Marshall Islands,1991-09-17,,,Marshall Islands
+478,MRT,ms,Mauritania,1961-10-27,,,Mauritania
+480,MUS,ms,Mauritius,1968-04-24,,,Mauritius
+484,MEX,ms,Mexico,1945-10-24,,,Mexico
+583,FSM,ms,Micronesia (Federated States of),1991-09-17,,,Micronesia (Federated States of)
+492,MCO,ms,Monaco,1993-05-28,,,Monaco
+496,MNG,ms,Mongolia,1961-10-27,,Official name before 12 Feb. 1992 was the Mongolian People's Republic,Mongolia
+499,MNE,ms,Montenegro,2006-06-28,,As from 3 June 2006: 'Montenegro'. Formerly: 'Serbia and Montenegro' until 2 June 2006.,Montenegro
+504,MAR,ms,Morocco,1956-12-11,,,Morocco
+508,MOZ,ms,Mozambique,1975-09-16,,,Mozambique
+104,MMR,fs,Burma,1948-04-19,1989-06-17,"On 18 June 1989, the Union of Burma informed the UN that it changed its name to the Union of Myanmar",Myanmar
+104,MMR,ms,Myanmar,1989-06-18,,"Formerly 'Burma' until 17 June 1989; Protocol memo dated 6 Apr. 2011 informed of the change of the official name from ""Union of Myanmar"" to ""Republic of the Union of Myanmar"" as of 30 March 2011; short name remains ""Myanmar""",Myanmar
+516,NAM,ms,Namibia,1990-04-23,,,Namibia
+520,NRU,ms,Nauru,1999-09-14,,,Nauru
+524,NPL,ms,Nepal,1955-12-14,,,Nepal
+528,NLD,fs,Netherlands,1945-10-24,2023-03-02,"The Kingdom of the Netherlands changed its short name from the Netherlands on 3 Mar. 2023, as per communication received from the Permanent Mission via Protocol.",Netherlands (Kingdom of the)
+528,NLD,ms,Netherlands (Kingdom of the),2023-03-03,,,Netherlands (Kingdom of the)
+554,NZL,ms,New Zealand,1945-10-24,,,New Zealand
+558,NIC,ms,Nicaragua,1945-10-24,,,Nicaragua
+562,NER,ms,Niger,1960-09-20,,,Niger
+566,NGA,ms,Nigeria,1960-10-07,,,Nigeria
+807,MKD,fs,The former Yugoslav Republic of Macedonia,1993-04-08,2019-02-13,"Further to the communication dated 14 Feb. 2019 from the Permanent Mission addressed to the Protocol and Liaison Service, the country name was changed to the 'Republic of North Macedonia' (short form: 'North Macedonia')",North Macedonia
+807,MKD,ms,North Macedonia,2019-02-14,,,North Macedonia
+578,NOR,ms,Norway,1945-10-24,,,Norway
+512,OMN,ms,Oman,1971-10-07,,,Oman
+586,PAK,ms,Pakistan,1947-09-30,,,Pakistan
+585,PLW,ms,Palau,1994-12-15,,,Palau
+591,PAN,ms,Panama,1945-10-24,,,Panama
+598,PNG,ms,Papua New Guinea,1975-10-10,,"As of 4 Mar. 2013, official name changed to 'Independent State of Papua New Guinea'",Papua New Guinea
+600,PRY,ms,Paraguay,1945-10-24,,,Paraguay
+604,PER,ms,Peru,1945-10-24,,,Peru
+608,PHL,fs,Philippine Commonwealth,1945-10-24,1946-07-03,,Philippines
+608,PHL,fs,Philippine Republic,1946-07-04,1946-12-31,,Philippines
+608,PHL,ms,Philippines,1947-01-01,,,Philippines
+616,POL,ms,Poland,1945-10-24,,,Poland
+620,PRT,ms,Portugal,1955-12-14,,,Portugal
+634,QAT,ms,Qatar,1971-09-21,,,Qatar
+410,KOR,ms,Republic of Korea,1991-09-17,,,Republic of Korea
+498,MDA,ms,Republic of Moldova,1992-02-03,,,Republic of Moldova
+642,ROU,ms,Romania,1955-12-14,,,Romania
+810,SUN,fs,USSR,1945-10-24,1991-12-23,"By a communication dated 24 Dec. 1991, the President of the Russian Federation notified the Secretary-General that membership of the USSR in the UN was continued by the Russian Federation",Russian Federation
+643,RUS,ms,Russian Federation,1991-12-24,,,Russian Federation
+646,RWA,ms,Rwanda,1962-09-18,,,Rwanda
+659,KNA,fs,Saint Christopher and Nevis,1983-09-23,1986-12-27,Known as 'Saint Christopher and Nevis' until 28 Dec. 1986,Saint Kitts and Nevis
+659,KNA,ms,Saint Kitts and Nevis,1986-12-28,,,Saint Kitts and Nevis
+662,LCA,ms,Saint Lucia,1979-09-18,,,Saint Lucia
+670,VCT,ms,Saint Vincent and the Grenadines,1980-09-16,,,Saint Vincent and the Grenadines
+882,WSM,ms,Samoa,1976-12-15,,,Samoa
+674,SMR,ms,San Marino,1992-03-02,,,San Marino
+678,STP,ms,Sao Tome and Principe,1975-09-16,,,Sao Tome and Principe
+682,SAU,ms,Saudi Arabia,1945-10-24,,,Saudi Arabia
+686,SEN,ms,Senegal,1960-09-28,,,Senegal
+688,SRB,fs,Serbia and Montenegro,2003-02-04,2006-06-02,Federal Republic of Yugoslavia changed its name to Serbia and Montenegro on 4 Feb. 2003; Montenegro's parliament declared independence from Serbia on 3 June 2006; Serbia officially proclaimed its independence on 5 June 2006,Serbia
+688,SRB,ms,Serbia,2006-06-03,,As from 3 June 2006: 'Serbia'. Formerly: 'Serbia and Montenegro' until 2 June 2006.,Serbia
+690,SYC,ms,Seychelles,1976-09-21,,,Seychelles
+694,SLE,ms,Sierra Leone,1961-09-27,,,Sierra Leone
+702,SGP,ms,Singapore,1965-09-21,,,Singapore
+703,SVK,ms,Slovakia,1993-01-19,,,Slovakia
+705,SVN,ms,Slovenia,1992-05-22,,,Slovenia
+090,SLB,ms,Solomon Islands,1978-09-19,,,Solomon Islands
+706,SOM,ms,Somalia,1960-09-20,,,Somalia
+710,ZAF,fs,Union of South Africa,1945-10-24,1961-05-31,,South Africa
+710,ZAF,ms,South Africa,1961-06-01,,,South Africa
+728,SSD,ms,South Sudan,2011-07-14,,"On 9 July 2011, the Republic of South Sudan was established upon its proclamation as an independent State.",South Sudan
+720,YMD,fs,Southern Yemen,1967-12-14,1970-11-29,"The Federation of South Arabia and the Protectorate of South Arabia became the 'People's Republic of South Yemen' on 30 Nov. 1967. On 30 Nov. 1970, the People's Republic of Southern Yemen (Southern Yemen) changed its name to People's Democratic Republic of Yemen (Democratic Yemen).",Southern Yemen
+724,ESP,ms,Spain,1955-12-14,,,Spain
+144,LKA,fs,Ceylon,1955-12-14,1972-08-28,Name changed from 'Ceylon' to 'Sri Lanka' on 29 Aug. 1972,Sri Lanka
+144,LKA,ms,Sri Lanka,1972-08-29,,,Sri Lanka
+729,SDN,ms,Sudan,1956-11-12,,,Sudan
+740,SUR,fs,Surinam,1975-12-04,1978-01-22,Name changed to Suriname on 23 Jan. 1978,Suriname
+740,SUR,ms,Suriname,1978-01-23,,,Suriname
+752,SWE,ms,Sweden,1946-11-09,,,Sweden
+756,CHE,ms,Switzerland,2002-09-10,,,Switzerland
+760,SYR,fs,Syria,1945-10-24,1958-02-21,,Syrian Arab Republic
+760,SYR,fs,Syria,1961-09-28,1971-09-12,,Syrian Arab Republic
+760,SYR,ms,Syrian Arab Republic,1971-09-13,,"In a communication dated 13 Sept. 1971, the Permanent Mission of the Syrian Arab Republic stated that the official name of 'Syria' was ""Syrian Arab Republic"".",Syrian Arab Republic
+762,TJK,ms,Tajikistan,1992-03-02,,,Tajikistan
+764,THA,fs,Siam,1946-12-15,1949-05-10,"'Siam' changed name to 'Thailand' on 24 June 1939, name changed back to 'Siam' on 7 Sept. 1945 and name reverted to 'Thailand' on 11 May 1949",Thailand
+764,THA,ms,Thailand,1949-05-11,,,Thailand
+626,TLS,ms,Timor-Leste,2002-09-27,,,Timor-Leste
+768,TGO,ms,Togo,1960-09-20,,,Togo
+776,TON,ms,Tonga,1999-09-14,,,Tonga
+780,TTO,ms,Trinidad and Tobago,1962-09-18,,,Trinidad and Tobago
+788,TUN,ms,Tunisia,1956-12-11,,,Tunisia
+792,TUR,fs,Turkey,1945-10-24,2022-05-25,"The 'Republic of Turkey' changed its official name to 'Republic of Türkiye' on 26 May 2022, as per communication received from the Permanent Mission via Protocol",Türkiye
+792,TUR,ms,Türkiye,2022-05-26,,,Türkiye
+795,TKM,ms,Turkmenistan,1992-03-02,,,Turkmenistan
+798,TUV,ms,Tuvalu,2000-05-09,,,Tuvalu
+800,UGA,ms,Uganda,1962-10-25,,,Uganda
+804,UKR,fs,Ukrainian SSR,1945-10-24,1991-08-23,"On 24 Aug. 1991, the 'Ukrainian Soviet Socialist Republic' changed its name to 'Ukraine'",Ukraine
+804,UKR,ms,Ukraine,1991-08-24,,,Ukraine
+784,ARE,ms,United Arab Emirates,1971-12-09,,,United Arab Emirates
+M09,UAR,fs,United Arab Republic,1958-02-22,1971-09-01,'Egypt' and 'Syria' united to form the 'United Arab Republic' from 22 Feb. 1958 to 27 Sept. 1961. 'Egypt' retained the name 'United Arab Republic' as its own official designation until 2 Sept. 1971.,United Arab Republic
+826,GBR,ms,United Kingdom,1945-10-24,,,United Kingdom
+M08,I08,fs,Tanganyika,1961-12-09,1964-04-26,"Following the ratification on 26 April 1964 of Articles of Union between Tanganyika and Zanzibar, 'Tanganyika' joined with 'Zanzibar' to form the 'United Republic of Tanganyika and Zanzibar', changing its name to the 'United Republic of Tanzania' on 1 Nov. 1964",United Republic of Tanganyika and Zanzibar
+M07,I07,fs,Zanzibar,1963-12-16,1964-04-26,"Following the ratification on 26 Apr. 1964 of Articles of Union between Tanganyika and Zanzibar, 'Tanganyika' joined with 'Zanzibar' to form the 'United Republic of Tanganyika and Zanzibar', changing its name to the 'United Republic of Tanzania' on 1 Nov. 1964",United Republic of Tanganyika and Zanzibar
+834,TZA,ms,United Republic of Tanzania,1964-02-11,,,United Republic of Tanzania
+834,TZA,fs,United Republic of Tanganyika and Zanzibar,1964-04-27,1964-11-01,"The 'United Republic of Tanganyika and Zanzibar' changed its name to the 'United Republic of Tanzania' on 1 Nov. 1964; in a communication addressed to the Secretary-General on 2 Nov. 1964, the Permanent Mission of the United Republic of Tanganyika and Zanzibar informed him that ""the United Republic of Tanganika and Zanzibar shall, with immediate effect, be known as the United Republic of Tanzania""",United Republic of Tanzania
+840,USA,ms,United States,1945-10-24,,,United States
+858,URY,ms,Uruguay,1945-10-24,,,Uruguay
+860,UZB,ms,Uzbekistan,1992-03-02,,,Uzbekistan
+548,VUT,ms,Vanuatu,1981-09-15,,,Vanuatu
+862,VEN,fs,Venezuela,1945-10-24,2004-11-17,Formal name changed from 'Venezuela' to 'Bolivarian Republic of Venezuela' in accordance with 1999 constitutional mandate,Venezuela (Bolivarian Republic of)
+862,VEN,ms,Venezuela (Bolivarian Republic of),2004-11-18,,"By letter of 17 Nov. 2004, the Permanent Mission specified that the short form be: 'Venezuela (Bolivarian Republic of)'",Venezuela (Bolivarian Republic of)
+704,VNM,ms,Viet Nam,1977-09-20,,"The Democratic Republic of Viet-Nam and the Republic of South Viet-Nam united on 2 July 1976 to constitute a new State, the 'Socialist Republic of Viet Nam', short name 'Viet Nam'",Viet Nam
+886,YEM,fs,Yemen Arab Republic,1947-09-30,1990-05-21,"Prior to 22 May 1990, the short form of the 'Yemen Arab Republic' was 'Yemen'.",Yemen
+887,YEM,ms,Yemen,1990-05-22,,,Yemen
+890,YUG,fs,Yugoslavia,1945-10-24,1992-04-26,Used for both pre-1992 six-member Socialist Federal Republic of Yugoslavia and succeeding two-member Federal Republic of Yugoslavia (27 Apr. 1992-3 Feb. 2003); the latter changed its name to Serbia and Montenegro as of 4 Feb. 2003,Yugoslavia
+890,YUG,fs,Yugoslavia,1992-04-27,2003-02-03,Used for both pre-1992 six-member Socialist Federal Republic of Yugoslavia and succeeding two-member Federal Republic of Yugoslavia (27 Apr. 1992-3 Feb. 2003); the latter changed its name to Serbia and Montenegro as of 4 Feb. 2003,Yugoslavia
+894,ZMB,ms,Zambia,1964-12-01,,,Zambia
+716,ZWE,ms,Zimbabwe,1980-08-25,,,Zimbabwe

--- a/app/data.py
+++ b/app/data.py
@@ -11,17 +11,58 @@ query_engine = ResolutionQueryEngine(repo=repo)
 
 available_countries = query_engine.get_available_countries()
 
+# Build name lookups from successor_states.csv
+_SUCCESSOR_STATES_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "successor_states.csv")
+_successor_df = pd.read_csv(_SUCCESSOR_STATES_PATH, parse_dates=["start_date", "end_date"])
+
+# Historical codes that pycountry can't resolve (truly retired states like SUN, DDR, CSK)
+# Maps code → (display_name, start_year, end_year)
+_HISTORICAL_NAME_MAP: dict[str, tuple[str, int, int]] = {}
+
+# Same-code name changes (Burma→Myanmar, Dahomey→Benin, etc.)
+# Maps current code → list of historical names for alias search
+_SAME_CODE_ALIASES: dict[str, list[str]] = {}
+
+for _ms_code, _group in _successor_df[_successor_df["status"] == "fs"].groupby("ms_code"):
+    if pycountry.countries.get(alpha_3=_ms_code) is None:
+        # Truly retired code — use the last (most recent) name as display name
+        _last = _group.sort_values("start_date").iloc[-1]
+        _start_year = int(_group["start_date"].min().year)
+        _end_year = int(_group["end_date"].dropna().max().year) if _group["end_date"].notna().any() else None
+        if _end_year:
+            _HISTORICAL_NAME_MAP[_ms_code] = (_last["ms_name"], _start_year, _end_year)
+    else:
+        # Same ISO3 code persists — collect historical names as search aliases
+        _aliases = _group["ms_name"].tolist()
+        if _aliases:
+            _SAME_CODE_ALIASES[_ms_code] = _aliases
+
+
 def get_country_name(
     iso3_code: str | None,
 ) -> str:  # we need to support multiple languages at some point
-    """Get English country name from ISO3 code."""
+    """Get English country name from ISO3 code, with year range for historical states."""
     if iso3_code is None:
         return "Unknown"
     try:
         country = pycountry.countries.get(alpha_3=iso3_code)
-        return country.name if country else iso3_code
+        if country:
+            return country.name
+        if iso3_code in _HISTORICAL_NAME_MAP:
+            name, start_year, end_year = _HISTORICAL_NAME_MAP[iso3_code]
+            return f"{name} ({start_year}\u2013{end_year})"
+        return iso3_code
     except:
         return iso3_code
+
+
+def get_country_search_terms(iso3_code: str) -> str:
+    """Return search string including historical name aliases for same-ISO3 name changes."""
+    base_name = get_country_name(iso3_code)
+    aliases = _SAME_CODE_ALIASES.get(iso3_code, [])
+    if aliases:
+        return " ".join([base_name] + aliases)
+    return base_name
 
 # Top level subjects (level 0 in the hierarchy)
 TOP_LEVEL_SUBJECTS = {

--- a/app/data.py
+++ b/app/data.py
@@ -12,7 +12,7 @@ query_engine = ResolutionQueryEngine(repo=repo)
 available_countries = query_engine.get_available_countries()
 
 # Build name lookups from successor_states.csv
-_SUCCESSOR_STATES_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "successor_states.csv")
+_SUCCESSOR_STATES_PATH = os.path.join(os.path.dirname(__file__), "assets", "successor_states.csv")
 _successor_df = pd.read_csv(_SUCCESSOR_STATES_PATH, parse_dates=["start_date", "end_date"])
 
 # Historical codes that pycountry can't resolve (truly retired states like SUN, DDR, CSK)

--- a/app/features/filters.py
+++ b/app/features/filters.py
@@ -389,7 +389,7 @@ layout = (
                                     {
                                         "label": data.get_country_name(country),
                                         "value": country,
-                                        "search": data.get_country_name(country),
+                                        "search": data.get_country_search_terms(country),
                                     }
                                     for country in data.available_countries
                                 ],
@@ -438,6 +438,7 @@ layout = (
                                             {
                                                 "label": data.get_country_name(country),
                                                 "value": country,
+                                                "search": data.get_country_search_terms(country),
                                             }
                                             for country in data.available_countries
                                         ],


### PR DESCRIPTION
## Summary
- Historical UN member state codes (`SUN`, `DDR`, `CSK`, `YUG`, `YMD`, `EAT`, `EAZ`, `SCG`, `GER`) now display with proper names and year ranges (e.g. _USSR (1945–1991)_) instead of raw 3-letter codes
- Same-ISO3 name changes (Burma→Myanmar, Khmer Republic→Cambodia, etc.) are added as search aliases so users can find countries by historical names
- `successor_states.csv` moved from `data/` (gitignored) to `app/assets/` so it's included in Docker builds automatically

## Changes
- `app/data.py` — builds `_HISTORICAL_NAME_MAP` and `_SAME_CODE_ALIASES` from `successor_states.csv` at startup; `get_country_name()` falls back to historical map; new `get_country_search_terms()` for alias search
- `app/features/filters.py` — both country dropdowns use `get_country_search_terms()` as the `search` field
- `app/assets/successor_states.csv` — new tracked asset (moved from `data/`); added entries for EAT, EAZ, SCG, GER

## Test plan
- [ ] Run `uv run python -m app` and open the Trends page
- [ ] Confirm `USSR (1945–1991)`, `Czechoslovakia (1945–1992)`, `German Democratic Republic (1973–1990)`, `Tanganyika (1961–1964)` etc. appear in the country dropdowns
- [ ] Type "Burma" → Myanmar appears; type "Khmer" → Cambodia appears
- [ ] Select USSR as main country → voting data loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)