### PR TITLE
feat: M49 region hierarchy tree select for country comparison

### DIFF
--- a/app/assets/m49_regional_groupings.csv
+++ b/app/assets/m49_regional_groupings.csv
@@ -1,0 +1,194 @@
+Global Code;Global Name;Region Code;Region Name;Sub-region Code;Sub-region Name;Intermediate Region Code;Intermediate Region Name;Country or Area;M49 Code;ISO-alpha2 Code;ISO-alpha3 Code;Least Developed Countries (LDC);Land Locked Developing Countries (LLDC);Small Island Developing States (SIDS)
+1;World;2.0;Africa;15.0;Northern Africa;;;Algeria;12;DZ;DZA;;;
+1;World;2.0;Africa;15.0;Northern Africa;;;Egypt;818;EG;EGY;;;
+1;World;2.0;Africa;15.0;Northern Africa;;;Libya;434;LY;LBY;;;
+1;World;2.0;Africa;15.0;Northern Africa;;;Morocco;504;MA;MAR;;;
+1;World;2.0;Africa;15.0;Northern Africa;;;Sudan;729;SD;SDN;x;;
+1;World;2.0;Africa;15.0;Northern Africa;;;Tunisia;788;TN;TUN;;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;14.0;Eastern Africa;Burundi;108;BI;BDI;x;x;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;14.0;Eastern Africa;Comoros;174;KM;COM;x;;x
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;14.0;Eastern Africa;Djibouti;262;DJ;DJI;x;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;14.0;Eastern Africa;Eritrea;232;ER;ERI;x;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;14.0;Eastern Africa;Ethiopia;231;ET;ETH;x;x;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;14.0;Eastern Africa;Kenya;404;KE;KEN;;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;14.0;Eastern Africa;Madagascar;450;MG;MDG;x;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;14.0;Eastern Africa;Malawi;454;MW;MWI;x;x;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;14.0;Eastern Africa;Mauritius;480;MU;MUS;;;x
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;14.0;Eastern Africa;Mozambique;508;MZ;MOZ;x;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;14.0;Eastern Africa;Rwanda;646;RW;RWA;x;x;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;14.0;Eastern Africa;Seychelles;690;SC;SYC;;;x
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;14.0;Eastern Africa;Somalia;706;SO;SOM;x;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;14.0;Eastern Africa;South Sudan;728;SS;SSD;x;x;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;14.0;Eastern Africa;Uganda;800;UG;UGA;x;x;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;14.0;Eastern Africa;United Republic of Tanzania;834;TZ;TZA;x;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;14.0;Eastern Africa;Zambia;894;ZM;ZMB;x;x;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;14.0;Eastern Africa;Zimbabwe;716;ZW;ZWE;;x;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;17.0;Middle Africa;Angola;24;AO;AGO;x;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;17.0;Middle Africa;Cameroon;120;CM;CMR;;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;17.0;Middle Africa;Central African Republic;140;CF;CAF;x;x;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;17.0;Middle Africa;Chad;148;TD;TCD;x;x;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;17.0;Middle Africa;Congo;178;CG;COG;;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;17.0;Middle Africa;Democratic Republic of the Congo;180;CD;COD;x;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;17.0;Middle Africa;Equatorial Guinea;226;GQ;GNQ;;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;17.0;Middle Africa;Gabon;266;GA;GAB;;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;17.0;Middle Africa;Sao Tome and Principe;678;ST;STP;;;x
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;18.0;Southern Africa;Botswana;72;BW;BWA;;x;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;18.0;Southern Africa;Eswatini;748;SZ;SWZ;;x;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;18.0;Southern Africa;Lesotho;426;LS;LSO;x;x;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;18.0;Southern Africa;Namibia;516;;NAM;;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;18.0;Southern Africa;South Africa;710;ZA;ZAF;;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;11.0;Western Africa;Benin;204;BJ;BEN;x;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;11.0;Western Africa;Burkina Faso;854;BF;BFA;x;x;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;11.0;Western Africa;Cabo Verde;132;CV;CPV;;;x
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;11.0;Western Africa;Côte d’Ivoire;384;CI;CIV;;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;11.0;Western Africa;Gambia;270;GM;GMB;x;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;11.0;Western Africa;Ghana;288;GH;GHA;;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;11.0;Western Africa;Guinea;324;GN;GIN;x;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;11.0;Western Africa;Guinea-Bissau;624;GW;GNB;x;;x
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;11.0;Western Africa;Liberia;430;LR;LBR;x;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;11.0;Western Africa;Mali;466;ML;MLI;x;x;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;11.0;Western Africa;Mauritania;478;MR;MRT;x;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;11.0;Western Africa;Niger;562;NE;NER;x;x;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;11.0;Western Africa;Nigeria;566;NG;NGA;;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;11.0;Western Africa;Senegal;686;SN;SEN;x;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;11.0;Western Africa;Sierra Leone;694;SL;SLE;x;;
+1;World;2.0;Africa;202.0;Sub-Saharan Africa;11.0;Western Africa;Togo;768;TG;TGO;x;;
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;29.0;Caribbean;Antigua and Barbuda;28;AG;ATG;;;x
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;29.0;Caribbean;Bahamas;44;BS;BHS;;;x
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;29.0;Caribbean;Barbados;52;BB;BRB;;;x
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;29.0;Caribbean;Cuba;192;CU;CUB;;;x
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;29.0;Caribbean;Dominica;212;DM;DMA;;;x
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;29.0;Caribbean;Dominican Republic;214;DO;DOM;;;x
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;29.0;Caribbean;Grenada;308;GD;GRD;;;x
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;29.0;Caribbean;Haiti;332;HT;HTI;x;;x
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;29.0;Caribbean;Jamaica;388;JM;JAM;;;x
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;29.0;Caribbean;Saint Kitts and Nevis;659;KN;KNA;;;x
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;29.0;Caribbean;Saint Lucia;662;LC;LCA;;;x
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;29.0;Caribbean;Saint Vincent and the Grenadines;670;VC;VCT;;;x
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;29.0;Caribbean;Trinidad and Tobago;780;TT;TTO;;;x
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;13.0;Central America;Belize;84;BZ;BLZ;;;x
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;13.0;Central America;Costa Rica;188;CR;CRI;;;
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;13.0;Central America;El Salvador;222;SV;SLV;;;
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;13.0;Central America;Guatemala;320;GT;GTM;;;
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;13.0;Central America;Honduras;340;HN;HND;;;
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;13.0;Central America;Mexico;484;MX;MEX;;;
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;13.0;Central America;Nicaragua;558;NI;NIC;;;
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;13.0;Central America;Panama;591;PA;PAN;;;
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;5.0;South America;Argentina;32;AR;ARG;;;
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;5.0;South America;Bolivia (Plurinational State of);68;BO;BOL;;x;
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;5.0;South America;Brazil;76;BR;BRA;;;
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;5.0;South America;Chile;152;CL;CHL;;;
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;5.0;South America;Colombia;170;CO;COL;;;
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;5.0;South America;Ecuador;218;EC;ECU;;;
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;5.0;South America;Guyana;328;GY;GUY;;;x
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;5.0;South America;Paraguay;600;PY;PRY;;x;
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;5.0;South America;Peru;604;PE;PER;;;
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;5.0;South America;Suriname;740;SR;SUR;;;x
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;5.0;South America;Uruguay;858;UY;URY;;;
+1;World;19.0;Americas;419.0;Latin America and the Caribbean;5.0;South America;Venezuela (Bolivarian Republic of);862;VE;VEN;;;
+1;World;19.0;Americas;21.0;Northern America;;;Canada;124;CA;CAN;;;
+1;World;19.0;Americas;21.0;Northern America;;;United States of America;840;US;USA;;;
+1;World;142.0;Asia;143.0;Central Asia;;;Kazakhstan;398;KZ;KAZ;;x;
+1;World;142.0;Asia;143.0;Central Asia;;;Kyrgyzstan;417;KG;KGZ;;x;
+1;World;142.0;Asia;143.0;Central Asia;;;Tajikistan;762;TJ;TJK;;x;
+1;World;142.0;Asia;143.0;Central Asia;;;Turkmenistan;795;TM;TKM;;x;
+1;World;142.0;Asia;143.0;Central Asia;;;Uzbekistan;860;UZ;UZB;;x;
+1;World;142.0;Asia;30.0;Eastern Asia;;;China;156;CN;CHN;;;
+1;World;142.0;Asia;30.0;Eastern Asia;;;Democratic People's Republic of Korea;408;KP;PRK;;;
+1;World;142.0;Asia;30.0;Eastern Asia;;;Japan;392;JP;JPN;;;
+1;World;142.0;Asia;30.0;Eastern Asia;;;Mongolia;496;MN;MNG;;x;
+1;World;142.0;Asia;30.0;Eastern Asia;;;Republic of Korea;410;KR;KOR;;;
+1;World;142.0;Asia;35.0;South-eastern Asia;;;Brunei Darussalam;96;BN;BRN;;;
+1;World;142.0;Asia;35.0;South-eastern Asia;;;Cambodia;116;KH;KHM;x;;
+1;World;142.0;Asia;35.0;South-eastern Asia;;;Indonesia;360;ID;IDN;;;
+1;World;142.0;Asia;35.0;South-eastern Asia;;;Lao People's Democratic Republic;418;LA;LAO;x;x;
+1;World;142.0;Asia;35.0;South-eastern Asia;;;Malaysia;458;MY;MYS;;;
+1;World;142.0;Asia;35.0;South-eastern Asia;;;Myanmar;104;MM;MMR;x;;
+1;World;142.0;Asia;35.0;South-eastern Asia;;;Philippines;608;PH;PHL;;;
+1;World;142.0;Asia;35.0;South-eastern Asia;;;Singapore;702;SG;SGP;;;x
+1;World;142.0;Asia;35.0;South-eastern Asia;;;Thailand;764;TH;THA;;;
+1;World;142.0;Asia;35.0;South-eastern Asia;;;Timor-Leste;626;TL;TLS;x;;x
+1;World;142.0;Asia;35.0;South-eastern Asia;;;Viet Nam;704;VN;VNM;;;
+1;World;142.0;Asia;34.0;Southern Asia;;;Afghanistan;4;AF;AFG;x;x;
+1;World;142.0;Asia;34.0;Southern Asia;;;Bangladesh;50;BD;BGD;x;;
+1;World;142.0;Asia;34.0;Southern Asia;;;Bhutan;64;BT;BTN;;x;
+1;World;142.0;Asia;34.0;Southern Asia;;;India;356;IN;IND;;;
+1;World;142.0;Asia;34.0;Southern Asia;;;Iran (Islamic Republic of);364;IR;IRN;;;
+1;World;142.0;Asia;34.0;Southern Asia;;;Maldives;462;MV;MDV;;;x
+1;World;142.0;Asia;34.0;Southern Asia;;;Nepal;524;NP;NPL;x;x;
+1;World;142.0;Asia;34.0;Southern Asia;;;Pakistan;586;PK;PAK;;;
+1;World;142.0;Asia;34.0;Southern Asia;;;Sri Lanka;144;LK;LKA;;;
+1;World;142.0;Asia;145.0;Western Asia;;;Armenia;51;AM;ARM;;x;
+1;World;142.0;Asia;145.0;Western Asia;;;Azerbaijan;31;AZ;AZE;;x;
+1;World;142.0;Asia;145.0;Western Asia;;;Bahrain;48;BH;BHR;;;
+1;World;142.0;Asia;145.0;Western Asia;;;Cyprus;196;CY;CYP;;;
+1;World;142.0;Asia;145.0;Western Asia;;;Georgia;268;GE;GEO;;;
+1;World;142.0;Asia;145.0;Western Asia;;;Iraq;368;IQ;IRQ;;;
+1;World;142.0;Asia;145.0;Western Asia;;;Israel;376;IL;ISR;;;
+1;World;142.0;Asia;145.0;Western Asia;;;Jordan;400;JO;JOR;;;
+1;World;142.0;Asia;145.0;Western Asia;;;Kuwait;414;KW;KWT;;;
+1;World;142.0;Asia;145.0;Western Asia;;;Lebanon;422;LB;LBN;;;
+1;World;142.0;Asia;145.0;Western Asia;;;Oman;512;OM;OMN;;;
+1;World;142.0;Asia;145.0;Western Asia;;;Qatar;634;QA;QAT;;;
+1;World;142.0;Asia;145.0;Western Asia;;;Saudi Arabia;682;SA;SAU;;;
+1;World;142.0;Asia;145.0;Western Asia;;;Syrian Arab Republic;760;SY;SYR;;;
+1;World;142.0;Asia;145.0;Western Asia;;;Türkiye;792;TR;TUR;;;
+1;World;142.0;Asia;145.0;Western Asia;;;United Arab Emirates;784;AE;ARE;;;
+1;World;142.0;Asia;145.0;Western Asia;;;Yemen;887;YE;YEM;x;;
+1;World;150.0;Europe;151.0;Eastern Europe;;;Belarus;112;BY;BLR;;;
+1;World;150.0;Europe;151.0;Eastern Europe;;;Bulgaria;100;BG;BGR;;;
+1;World;150.0;Europe;151.0;Eastern Europe;;;Czechia;203;CZ;CZE;;;
+1;World;150.0;Europe;151.0;Eastern Europe;;;Hungary;348;HU;HUN;;;
+1;World;150.0;Europe;151.0;Eastern Europe;;;Poland;616;PL;POL;;;
+1;World;150.0;Europe;151.0;Eastern Europe;;;Republic of Moldova;498;MD;MDA;;x;
+1;World;150.0;Europe;151.0;Eastern Europe;;;Romania;642;RO;ROU;;;
+1;World;150.0;Europe;151.0;Eastern Europe;;;Russian Federation;643;RU;RUS;;;
+1;World;150.0;Europe;151.0;Eastern Europe;;;Slovakia;703;SK;SVK;;;
+1;World;150.0;Europe;151.0;Eastern Europe;;;Ukraine;804;UA;UKR;;;
+1;World;150.0;Europe;154.0;Northern Europe;;;Denmark;208;DK;DNK;;;
+1;World;150.0;Europe;154.0;Northern Europe;;;Estonia;233;EE;EST;;;
+1;World;150.0;Europe;154.0;Northern Europe;;;Finland;246;FI;FIN;;;
+1;World;150.0;Europe;154.0;Northern Europe;;;Iceland;352;IS;ISL;;;
+1;World;150.0;Europe;154.0;Northern Europe;;;Ireland;372;IE;IRL;;;
+1;World;150.0;Europe;154.0;Northern Europe;;;Latvia;428;LV;LVA;;;
+1;World;150.0;Europe;154.0;Northern Europe;;;Lithuania;440;LT;LTU;;;
+1;World;150.0;Europe;154.0;Northern Europe;;;Norway;578;NO;NOR;;;
+1;World;150.0;Europe;154.0;Northern Europe;;;Sweden;752;SE;SWE;;;
+1;World;150.0;Europe;154.0;Northern Europe;;;United Kingdom of Great Britain and Northern Ireland;826;GB;GBR;;;
+1;World;150.0;Europe;39.0;Southern Europe;;;Albania;8;AL;ALB;;;
+1;World;150.0;Europe;39.0;Southern Europe;;;Andorra;20;AD;AND;;;
+1;World;150.0;Europe;39.0;Southern Europe;;;Bosnia and Herzegovina;70;BA;BIH;;;
+1;World;150.0;Europe;39.0;Southern Europe;;;Croatia;191;HR;HRV;;;
+1;World;150.0;Europe;39.0;Southern Europe;;;Greece;300;GR;GRC;;;
+1;World;150.0;Europe;39.0;Southern Europe;;;Italy;380;IT;ITA;;;
+1;World;150.0;Europe;39.0;Southern Europe;;;Malta;470;MT;MLT;;;
+1;World;150.0;Europe;39.0;Southern Europe;;;Montenegro;499;ME;MNE;;;
+1;World;150.0;Europe;39.0;Southern Europe;;;North Macedonia;807;MK;MKD;;x;
+1;World;150.0;Europe;39.0;Southern Europe;;;Portugal;620;PT;PRT;;;
+1;World;150.0;Europe;39.0;Southern Europe;;;San Marino;674;SM;SMR;;;
+1;World;150.0;Europe;39.0;Southern Europe;;;Serbia;688;RS;SRB;;;
+1;World;150.0;Europe;39.0;Southern Europe;;;Slovenia;705;SI;SVN;;;
+1;World;150.0;Europe;39.0;Southern Europe;;;Spain;724;ES;ESP;;;
+1;World;150.0;Europe;155.0;Western Europe;;;Austria;40;AT;AUT;;;
+1;World;150.0;Europe;155.0;Western Europe;;;Belgium;56;BE;BEL;;;
+1;World;150.0;Europe;155.0;Western Europe;;;France;250;FR;FRA;;;
+1;World;150.0;Europe;155.0;Western Europe;;;Germany;276;DE;DEU;;;
+1;World;150.0;Europe;155.0;Western Europe;;;Liechtenstein;438;LI;LIE;;;
+1;World;150.0;Europe;155.0;Western Europe;;;Luxembourg;442;LU;LUX;;;
+1;World;150.0;Europe;155.0;Western Europe;;;Monaco;492;MC;MCO;;;
+1;World;150.0;Europe;155.0;Western Europe;;;Netherlands (Kingdom of the);528;NL;NLD;;;
+1;World;150.0;Europe;155.0;Western Europe;;;Switzerland;756;CH;CHE;;;
+1;World;9.0;Oceania;53.0;Australia and New Zealand;;;Australia;36;AU;AUS;;;
+1;World;9.0;Oceania;53.0;Australia and New Zealand;;;New Zealand;554;NZ;NZL;;;
+1;World;9.0;Oceania;54.0;Melanesia;;;Fiji;242;FJ;FJI;;;x
+1;World;9.0;Oceania;54.0;Melanesia;;;Papua New Guinea;598;PG;PNG;;;x
+1;World;9.0;Oceania;54.0;Melanesia;;;Solomon Islands;90;SB;SLB;x;;x
+1;World;9.0;Oceania;54.0;Melanesia;;;Vanuatu;548;VU;VUT;;;x
+1;World;9.0;Oceania;57.0;Micronesia;;;Kiribati;296;KI;KIR;x;;x
+1;World;9.0;Oceania;57.0;Micronesia;;;Marshall Islands;584;MH;MHL;;;x
+1;World;9.0;Oceania;57.0;Micronesia;;;Micronesia (Federated States of);583;FM;FSM;;;x
+1;World;9.0;Oceania;57.0;Micronesia;;;Nauru;520;NR;NRU;;;x
+1;World;9.0;Oceania;57.0;Micronesia;;;Palau;585;PW;PLW;;;x
+1;World;9.0;Oceania;61.0;Polynesia;;;Samoa;882;WS;WSM;;;x
+1;World;9.0;Oceania;61.0;Polynesia;;;Tonga;776;TO;TON;;;x
+1;World;9.0;Oceania;61.0;Polynesia;;;Tuvalu;798;TV;TUV;x;;x

--- a/app/data.py
+++ b/app/data.py
@@ -64,6 +64,141 @@ def get_country_search_terms(iso3_code: str) -> str:
         return " ".join([base_name] + aliases)
     return base_name
 
+
+# Build M49 region tree for AntdTreeSelect
+_M49_PATH = os.path.join(os.path.dirname(__file__), "assets", "m49_regional_groupings.csv")
+
+
+def get_region_tree_data() -> list[dict]:
+    """Build nested treeData for AntdTreeSelect from M49 regional groupings CSV.
+
+    Returns a nested hierarchy: World → Region → Sub-region → [Intermediate Region] → Country.
+    Each node has: key, title, value, and children (list of child nodes).
+    """
+    df = pd.read_csv(_M49_PATH, sep=";")
+
+    # Collect nodes by code for deduplication and parent lookup
+    regions: dict[str, dict] = {}
+    sub_regions: dict[str, dict] = {}
+    inter_regions: dict[str, dict] = {}
+    countries: dict[str, dict] = {}
+
+    # Track parent relationships
+    region_to_world: dict[str, bool] = {}
+    sub_to_region: dict[str, str] = {}
+    inter_to_sub: dict[str, str] = {}
+    country_to_parent: dict[str, str] = {}
+
+    for _, row in df.iterrows():
+        iso3 = row.get("ISO-alpha3 Code")
+        if not isinstance(iso3, str) or not iso3.strip():
+            continue
+
+        # Region
+        r_code = str(int(float(row["Region Code"]))).zfill(3)
+        if r_code not in regions:
+            regions[r_code] = {"key": r_code, "title": row["Region Name"], "value": r_code}
+            region_to_world[r_code] = True
+
+        # Sub-region
+        sr_code = str(int(float(row["Sub-region Code"]))).zfill(3)
+        if sr_code not in sub_regions:
+            sub_regions[sr_code] = {"key": sr_code, "title": row["Sub-region Name"], "value": sr_code}
+            sub_to_region[sr_code] = r_code
+
+        # Intermediate region (optional)
+        parent_code = sr_code
+        ir_raw = row.get("Intermediate Region Code")
+        if isinstance(ir_raw, float) and not pd.isna(ir_raw):
+            ir_code = str(int(ir_raw)).zfill(3)
+            if ir_code not in inter_regions:
+                inter_regions[ir_code] = {"key": ir_code, "title": row["Intermediate Region Name"], "value": ir_code}
+                inter_to_sub[ir_code] = sr_code
+            parent_code = ir_code
+
+        # Country leaf
+        if iso3 not in countries:
+            countries[iso3] = {"key": iso3, "title": get_country_name(iso3), "value": iso3}
+            country_to_parent[iso3] = parent_code
+
+    # Build tree bottom-up: attach countries to their parents
+    for iso3, node in countries.items():
+        parent = country_to_parent[iso3]
+        if parent in inter_regions:
+            inter_regions[parent].setdefault("children", []).append(node)
+        elif parent in sub_regions:
+            sub_regions[parent].setdefault("children", []).append(node)
+
+    # Attach intermediate regions to sub-regions
+    for ir_code, node in inter_regions.items():
+        sr_code = inter_to_sub[ir_code]
+        sub_regions[sr_code].setdefault("children", []).append(node)
+
+    # Attach sub-regions to regions
+    for sr_code, node in sub_regions.items():
+        r_code = sub_to_region[sr_code]
+        regions[r_code].setdefault("children", []).append(node)
+
+    # Use joining_dates.csv as the authoritative source for countries with voting data
+    _joining_path = os.path.join(os.path.dirname(__file__), "assets", "joining_dates.csv")
+    _voting_df = pd.read_csv(_joining_path)
+    valid = set(_voting_df["country"].tolist())
+
+    for parent_dict in [inter_regions, sub_regions]:
+        for code, node in parent_dict.items():
+            if "children" in node:
+                node["children"] = [
+                    c for c in node["children"]
+                    if "children" in c or c["value"] in valid  # keep groups, filter leaves
+                ]
+
+    # Remove empty intermediate/sub-region/region nodes (no children left)
+    for ir_code, node in list(inter_regions.items()):
+        if not node.get("children"):
+            sr_code = inter_to_sub[ir_code]
+            sub_regions[sr_code]["children"] = [
+                c for c in sub_regions[sr_code].get("children", []) if c["key"] != ir_code
+            ]
+
+    for sr_code, node in list(sub_regions.items()):
+        if not node.get("children"):
+            r_code = sub_to_region[sr_code]
+            regions[r_code]["children"] = [
+                c for c in regions[r_code].get("children", []) if c["key"] != sr_code
+            ]
+
+    # Build world root with regions as children
+    world = {
+        "key": "001",
+        "title": "World",
+        "value": "001",
+        "children": [r for r in regions.values() if r.get("children")],
+    }
+
+    # Add historical countries (voted but no longer in M49)
+    m49_codes = set(countries.keys())
+    historical_codes = sorted(valid - m49_codes)
+    historical_children = []
+    for code in historical_codes:
+        name = get_country_name(code)
+        historical_children.append({"key": code, "title": name, "value": code})
+
+    if historical_children:
+        historical_node = {
+            "key": "historical",
+            "title": "Historical States",
+            "value": "historical",
+            "children": historical_children,
+        }
+        print(f"Region tree: {len(m49_codes)} current + {len(historical_children)} historical countries")
+        return [world, historical_node]
+
+    print(f"Region tree: {len(m49_codes)} current countries, no historical found")
+    return [world]
+
+
+REGION_TREE_DATA = get_region_tree_data()
+
 # Top level subjects (level 0 in the hierarchy)
 TOP_LEVEL_SUBJECTS = {
     'http://metadata.un.org/thesaurus/10', 

--- a/app/features/filters.py
+++ b/app/features/filters.py
@@ -1,4 +1,5 @@
 from dash import Input, Output, State, callback, clientside_callback, html, dcc
+import feffery_antd_components as fac
 import pandas as pd
 import urllib.parse
 
@@ -432,25 +433,19 @@ layout = (
                                             ),
                                         ]
                                     ),
-                                    dcc.Dropdown(
+                                    fac.AntdTreeSelect(
                                         id=ids["country2"],
-                                        options=[
-                                            {
-                                                "label": data.get_country_name(country),
-                                                "value": country,
-                                                "search": data.get_country_search_terms(country),
-                                            }
-                                            for country in data.available_countries
-                                        ],
-                                        value=[],
-                                        multi=True,
-                                        clearable=False,
-                                        placeholder="Select countries to compare...",
-                                        style={
-                                            "width": "100%",
-                                            "fontSize": "14px",
-                                        },
-                                        searchable=True,
+                                        treeData=data.REGION_TREE_DATA,
+                                        treeCheckable=True,
+                                        showCheckedStrategy="show-child",
+                                        treeNodeFilterProp="title",
+                                        placeholder="Search or browse countries...",
+                                        allowClear=True,
+                                        multiple=True,
+                                        treeDefaultExpandAll=False,
+                                        treeLine=True,
+                                        style={"width": "100%"},
+                                        locale="en-us",
                                     ),
                                 ],
                                 style={"flex": "1"},

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -9,3 +9,4 @@ rdflib==7.5.0
 Requests==2.32.5
 wordcloud==1.9.4
 rapidfuzz==3.13.0
+feffery-antd-components>=0.4.5


### PR DESCRIPTION
## Summary
- Replaced the flat "Compare with" country dropdown with an **AntdTreeSelect** showing the full UN M49 geographic hierarchy: World → Region → Sub-region → [Intermediate Region] → Country
- Added a **Historical States** top-level node with 9 dissolved states (USSR, Yugoslavia, Czechoslovakia, etc.) that have voting records
- Only countries with actual voting data are included as selectable leaves
- Tree supports search-by-name filtering, checkbox selection of entire regions, and hierarchical browsing

## Changed files
- `app/data.py` — added `get_region_tree_data()` to build nested tree from M49 CSV
- `app/features/filters.py` — swapped `dcc.Dropdown` for `fac.AntdTreeSelect` on the comparison field
- `app/requirements.txt` — added `feffery-antd-components>=0.4.5`
- `app/assets/m49_regional_groupings.csv` — M49 regional groupings data (193 UN member states)

## Test plan
- [ ] Open Trends page → "Compare with" shows a tree select instead of flat dropdown
- [ ] Expand World → Africa → Eastern Africa → verify countries listed
- [ ] Check a region checkbox → verify all child countries are selected
- [ ] Type a country name → verify search filters the tree correctly
- [ ] Expand "Historical States" → verify 9 dissolved states are listed
- [ ] Quick Select presets still populate the tree select correctly
- [ ] Reset button clears the tree selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)