### PR TITLE
feat: session-based agreement timeline

### DIFF
--- a/app/features/agreement_graph.py
+++ b/app/features/agreement_graph.py
@@ -1,6 +1,7 @@
 from dash import dcc, Input, Output, callback, html
 import plotly.graph_objects as go
 import pandas as pd
+import numpy as np
 from io import StringIO
 from ..data import get_country_name
 
@@ -17,78 +18,89 @@ def register_callbacks():
             Input("moving-average-data", "data"),
         ],
     )
-    def generate_chart(filter_store, moving_average_data):
-        # moving_average_data is JSON produced by to_json; parse it
-        if moving_average_data is None or not filter_store:
+    def generate_chart(filter_store, session_data):
+        if session_data is None or not filter_store:
             return go.Figure(), html.Div("No data"), ""
 
         country1 = filter_store.get("country1_alpha3")
         country2 = filter_store.get("country2")
 
-        df = pd.read_json(StringIO(moving_average_data))
-        df["date"] = pd.to_datetime(df["date"])
+        df = pd.read_json(StringIO(session_data))
 
         # ensure country2 is a list
         selected = country2 if isinstance(country2, (list, tuple)) else [country2]
 
+        # detect special/emergency sessions (contain "sp" e.g. "1sp", "7emsp")
+        is_special = df["session"].astype(str).str.contains("sp", case=False, na=False)
+
         fig = go.Figure()
-        colors = ["blue", "orange", "green", "red", "purple", "brown", "pink", "gray", "olive", "cyan"]
+        colors = ["blue", "orange", "green", "purple", "brown", "pink", "gray", "olive", "cyan", "teal"]
         for i, c in enumerate(selected):
-            sma_col = f"sma_{c}"
-            align_col = f"agreement_{c}"
-            if sma_col in df.columns:
-                fig.add_trace(
-                    go.Scatter(
-                        x=df["date"],
-                        y=df[sma_col],
-                        mode="lines",
-                        name=f"{get_country_name(c)}",  # f"{c} ({country1}) SMA",
-                        line=dict(color=colors[i % len(colors)]),
-                    )
+            avg_col = f"avg_agreement_{c}"
+            n_col = f"n_votes_{c}"
+            if avg_col not in df.columns:
+                continue
+
+            # filter to non-NaN rows so all dots are connected
+            mask = df[avg_col].notna()
+            df_c = df.loc[mask].copy()
+            special_c = is_special.loc[mask]
+            country_color = colors[i % len(colors)]
+
+            hover_data = np.column_stack([
+                df_c["session"].values,
+                df_c[n_col].values if n_col in df_c.columns else np.zeros(len(df_c)),
+            ])
+
+            # per-point marker colors: red for special sessions, country color otherwise
+            marker_colors = ["red" if s else country_color for s in special_c]
+
+            fig.add_trace(
+                go.Scatter(
+                    x=df_c["year"],
+                    y=df_c[avg_col],
+                    mode="markers+lines",
+                    name=get_country_name(c),
+                    line=dict(color=country_color),
+                    marker=dict(size=6, color=marker_colors),
+                    customdata=hover_data,
+                    hovertemplate=(
+                        "Session %{customdata[0]}<br>"
+                        "Year: %{x}<br>"
+                        "Agreement: %{y:.3f}<br>"
+                        "Shared votes: %{customdata[1]:.0f}"
+                        "<extra>%{fullData.name}</extra>"
+                    ),
                 )
-            elif align_col in df.columns:
-                fig.add_trace(
-                    go.Scatter(
-                        x=df["date"],
-                        y=df[align_col],
-                        mode="lines",
-                        name=f"{c} ({country1}) agreement",
-                        line=dict(color=colors[i % len(colors)]),
-                    )
-                )
+            )
 
         fig.update_layout(
             title=f"Agreement: {get_country_name(country1)} vs {', '.join([get_country_name(c) for c in selected])}",
-            xaxis_title="Date",
+            xaxis_title="Year",
             yaxis_title="Agreement Score",
             yaxis=dict(range=[0, 1]),
             template="plotly_white",
         )
 
         # status message
-        total_points = len(df)
-        start_str = (
-            df["date"].min().strftime("%Y-%m-%d")
-            if not df["date"].isna().all()
-            else "N/A"
-        )
-        end_str = (
-            df["date"].max().strftime("%Y-%m-%d")
-            if not df["date"].isna().all()
-            else "N/A"
-        )
+        n_sessions = len(df)
+        year_min = int(df["year"].min()) if not df["year"].isna().all() else "N/A"
+        year_max = int(df["year"].max()) if not df["year"].isna().all() else "N/A"
         country1_name = get_country_name(country1)
         status_msg = html.Div(
-            f"Overlapping vote period: {start_str} to {end_str} ({total_points:,} data points).",
+            f"Covers {n_sessions} sessions from {year_min} to {year_max}.",
             style={"color": "#7f8c8d", "fontSize": "14px", "padding": "4px 0"},
         )
 
         note_msg = html.P([
             html.Strong("Note: "),
-            f"The chart shows the moving average of the pairwise vote agreement between {country1_name} "
-            "and the selected comparison countries over time. An agreement score of 1 means that "
-            "two countries voted the same on all General Assembly (GA) resolutions within the moving window. "
-            'A score of 0 means that two countries always voted in opposite ways ("yes" vs. "no"). '
+            f"The chart shows the average pairwise vote agreement between {country1_name} "
+            "and the selected comparison countries per UN General Assembly session. "
+            "Each point represents the mean agreement score across all resolutions in that session "
+            "where both countries voted. An agreement score of 1 means identical votes on all resolutions; "
+            '0 means complete disagreement ("yes" vs. "no"). '
+            "Only sessions with at least 3 shared votes are shown. "
+            "Red dots indicate special or emergency sessions. "
             "The data only covers GA resolutions that were passed (accepted)."
         ], style={
             "maxWidth": "100%",

--- a/app/pages/trends_page.py
+++ b/app/pages/trends_page.py
@@ -287,8 +287,8 @@ def update_tab_states(filter_store):
         timeline_content = [
             html.H2("Pairwise Agreement over Time"),
             html.P(
-                f"Tracks how voting agreement between {country1_name} and the selected comparison countries has evolved over time using a moving average. "
-                f"The graph starts from the first resolution where both {country1_name} and any chosen comparison country have voted.",
+                f"Tracks how voting agreement between {country1_name} and the selected comparison countries has evolved across UN General Assembly sessions. "
+                f"Each point represents the average agreement for one session. Only sessions with at least 3 shared votes are shown.",
                 style={"color": "#7f8c8d", "marginBottom": "20px"},
             ),
             *agreement_graph.layout,
@@ -538,56 +538,44 @@ def _calculate_data_wrapper(filter_store):
         return ("No comparison country selected.", None, None)
     selected_tuple = tuple(country2) if isinstance(country2, list) else (country2,)
 
-    return _calculate_data_uncached(country1, selected_tuple, 350)
+    return _calculate_data_uncached(country1, selected_tuple)
 
 
 @functools.lru_cache(maxsize=100)
-def _calculate_data_uncached(
-    country1: str | None, selected_tuple: tuple, time_span: int
-):
-    """Calculate moving average data for country pair (cached)."""
+def _calculate_data_uncached(country1: str | None, selected_tuple: tuple):
+    """Calculate per-session agreement data for country pairs (cached)."""
     if country1 is None:
-        # Don't calculate yet if no primary country is selected
         return (None, None, None)
 
-    # Normalize country2 to a list
-    selected = list(selected_tuple)  # convert back to list for processing
-
-    # remove country1 if accidentally selected
+    selected = list(selected_tuple)
     selected = [c for c in selected if c != country1]
     if len(selected) == 0:
         return (None, None, None)
 
-    print(f"🔄 Calculating {country1} vs {selected} (span: {time_span})")
+    print(f"🔄 Calculating session agreement: {country1} vs {selected}")
     start_time = time.time()
 
     try:
         vote_mapping = {"Y": 1, "A": 0, "N": -1}
 
-        # Pull only required columns
-        cols = ["date", country1] + selected
+        cols = ["date", "session", country1] + selected
         df = data.query_engine.query_resolutions()[cols].copy()
 
-        # normalize and map votes to numeric (robust handling)
+        # normalize and map votes to numeric
         vote_cols = [country1] + selected
-        # convert to string, strip whitespace, uppercase
         df[vote_cols] = (
             df[vote_cols].astype(str).apply(lambda s: s.str.strip().str.upper())
         )
-        # replace common null-like strings with actual NaN
         df[vote_cols] = df[vote_cols].replace(
             {"": pd.NA, "NAN": pd.NA, "NONE": pd.NA, "<NA>": pd.NA}
         )
-        # map to numbers
         df[vote_cols] = df[vote_cols].replace(vote_mapping)
-        # coerce any remaining non-numeric to NaN
         df[vote_cols] = df[vote_cols].apply(pd.to_numeric, errors="coerce")
 
-        # ensure dates and sort
         df["date"] = pd.to_datetime(df["date"], errors="coerce")
         df = df.sort_values("date").reset_index(drop=True)
 
-        # start after first row where country1 and at least one selected country voted
+        # check that at least one overlapping vote exists
         mask_any = (~df[country1].isna()) & df[selected].notna().any(axis=1)
         if not mask_any.any():
             return (
@@ -609,51 +597,60 @@ def _calculate_data_uncached(
                 None,
                 None,
             )
-        first_pos = mask_any.values.argmax()
 
-        # Keep a reference to the original df for finding last vote dates
-        df_original = df.copy()
-        df = df.iloc[first_pos:].reset_index(drop=True)
-
-        # compute per-country agreement (vectorized)
+        # compute per-resolution agreement (vectorized)
         diffs = df[selected].subtract(df[country1], axis=0).abs()
         agreement = 1.0 - (diffs / 2.0)
 
-        # set agreement to NaN where either side didn't vote
         for col in selected:
             both_voted = df[[country1, col]].notna().all(axis=1)
             agreement[col] = agreement[col].where(both_voted, np.nan)
 
-        # build output dataframe with per-country agreement and moving averages
-        out = pd.DataFrame({"date": df["date"]})
+        # build temporary df for session-level groupby
+        tmp = pd.DataFrame({"session": df["session"], "date": df["date"]})
         for col in selected:
-            align_col = f"agreement_{col}"
-            sma_col = f"sma_{col}"
+            tmp[f"agreement_{col}"] = agreement[col]
 
-            out[align_col] = agreement[col]
+        # derive year per session (median date's year)
+        session_year = tmp.groupby("session")["date"].median().dt.year
+        session_year.name = "year"
 
-            out[sma_col] = (
-                out[align_col]
-                .rolling(window=time_span, min_periods=time_span // 4)
-                .mean()
-            )
+        # aggregate per session per country
+        out_parts = [session_year]
+        for col in selected:
+            agree_col = f"agreement_{col}"
+            avg_col = f"avg_agreement_{col}"
+            n_col = f"n_votes_{col}"
 
-            # Find the last date this country actually voted
-            # Use the original unfiltered df to find the last non-null vote for this country
-            last_vote_mask = df_original[col].notna()
-            if last_vote_mask.any():
-                last_vote_date = df_original.loc[last_vote_mask, "date"].max()
-                print(f"  📅 {col}: Last vote date = {last_vote_date}")
-                # Set both agreement AND moving average to NaN for dates after the last vote
-                rows_set_to_nan = (out["date"] > last_vote_date).sum()
-                out.loc[out["date"] > last_vote_date, align_col] = np.nan
-                out.loc[out["date"] > last_vote_date, sma_col] = np.nan
-                print(f"      Set {rows_set_to_nan} rows to NaN after {last_vote_date}")
+            grouped = tmp.groupby("session")[agree_col]
+            avg_agreement = grouped.mean()
+            avg_agreement.name = avg_col
+            n_votes = grouped.apply(lambda x: x.notna().sum())
+            n_votes.name = n_col
+
+            # minimum 3 votes threshold
+            avg_agreement = avg_agreement.where(n_votes >= 3, np.nan)
+
+            out_parts.extend([avg_agreement, n_votes])
+
+        out = pd.concat(out_parts, axis=1).reset_index()
+        out = out.sort_values(["year", "session"]).reset_index(drop=True)
+
+        # last-vote cutoff: find last session each country voted in
+        for col in selected:
+            avg_col = f"avg_agreement_{col}"
+            n_col = f"n_votes_{col}"
+            has_votes = out[avg_col].notna()
+            if has_votes.any():
+                last_idx = has_votes.values[::-1].argmax()
+                last_session_pos = len(has_votes) - 1 - last_idx
+                out.loc[out.index[last_session_pos + 1:], avg_col] = np.nan
+                print(f"  📅 {col}: last active session = {out.loc[out.index[last_session_pos], 'session']}")
 
         calc_time = time.time() - start_time
-        print(f"✅ Calculated in {calc_time:.2f}s ({len(out):,} points)")
+        print(f"✅ Calculated in {calc_time:.2f}s ({len(out)} sessions)")
 
-        return (None, out.to_json(date_format="iso"), calc_time)
+        return (None, out.to_json(), calc_time)
 
     except Exception as e:
         print(f"❌ Calculation error: {e}")


### PR DESCRIPTION
## Summary
- Replaces the rolling moving average agreement timeline with a session-based scatter plot
- Each point represents the average voting agreement for one UN General Assembly session, connected in temporal order
- Special/emergency sessions (e.g. `7emsp`) are highlighted with red dots
- Sessions with fewer than 3 shared votes between countries are excluded to reduce noise
- Hover tooltips show session number, year, agreement score, and shared vote count

## Test plan
- [ ] Select a main country and 2-3 comparison countries, verify scatter plot with connected dots appears
- [ ] Hover over points to confirm session info, year, agreement, and vote count display correctly
- [ ] Verify red dots appear for special/emergency sessions
- [ ] Select a historical country (e.g. DDR) and confirm the line stops at the last active session
- [ ] Confirm other tabs (map, subject, word cloud) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)