### PR TITLE
Rename 'Note' to 'Details'

### DIFF
--- a/app/features/agreement_choropleth.py
+++ b/app/features/agreement_choropleth.py
@@ -144,7 +144,7 @@ def register_callbacks(query_engine):
         # f"{country1_name} is highlighted in green.
         note_msg = html.P(
             [
-                html.Strong("Note: "),
+                html.Strong("Details: "),
                 f"The map shows the pairwise vote agreement between {country1_name} and all "
                 "other countries (UN member states). An agreement score of 1 (dark blue) means that two countries "
                 "voted the same on all General Assembly (GA) resolutions. A score of 0 (dark red) means that "

--- a/app/features/agreement_choropleth.py
+++ b/app/features/agreement_choropleth.py
@@ -112,7 +112,7 @@ def register_callbacks(query_engine):
                 z=[1],  # dummy value
                 colorscale=[[0, "green"], [1, "green"]],  # solid green color
                 showscale=False,
-                hovertemplate=f"<b>{country1}</b> (Selected)<extra></extra>",
+                hovertemplate=f"<b>{data.get_country_display_name(country1)}</b> (Selected)<extra></extra>",
                 marker_line_color="black",
                 marker_line_width=2,
             )

--- a/app/features/agreement_graph.py
+++ b/app/features/agreement_graph.py
@@ -84,7 +84,7 @@ def register_callbacks():
         )
 
         note_msg = html.P([
-            html.Strong("Note: "),
+            html.Strong("Details: "),
             f"The chart shows the moving average of the pairwise vote agreement between {country1_name} "
             "and the selected comparison countries over time. An agreement score of 1 means that "
             "two countries voted the same on all General Assembly (GA) resolutions within the moving window. "


### PR DESCRIPTION
## Features

- Rename 'Note' to 'Details'
- Fix the selected country not using the historical display name in the choropleth feature