### PR TITLE
Tiny UI changes (World Map feature)

### DIFF
--- a/app/features/agreement_choropleth.py
+++ b/app/features/agreement_choropleth.py
@@ -88,10 +88,15 @@ def register_callbacks(query_engine):
         no_shared_votes = agreement_data[agreement_data["agreement_raw"].isna()].copy()
         agreement_data = agreement_data[agreement_data["agreement_raw"].notna()]
 
+        # Plot the choropleth world map
+        # Note: Recent `plotly` versions actually seem to use an official
+        # UN data source to generate simplified geometries for the world map.
+        # See the description of this plotly PR:
+        # https://github.com/plotly/plotly.js/pull/7393
         fig = px.choropleth(
             agreement_data,
             color="agreement_raw",
-            color_continuous_scale=px.colors.sequential.RdBu,
+            color_continuous_scale=px.colors.diverging.RdYlBu,  # Red-Yellow-Blue
             range_color=[0, 1],
             locations="three_letter_country",
             projection="robinson",

--- a/app/features/agreement_choropleth.py
+++ b/app/features/agreement_choropleth.py
@@ -176,12 +176,13 @@ def register_callbacks(query_engine):
         note_msg = html.P(
             [
                 html.Strong("Details: "),
-                f"The map shows the pairwise vote agreement between {country1_name} and "
-                "other countries (UN member states). An agreement score of 1 (dark blue) means that two countries "
-                "voted the same on all General Assembly (GA) resolutions. A score of 0 (dark red) means that "
-                'two countries always voted in opposite ways ("yes" vs. "no"). The data only covers GA resolutions '
-                "that were passed (accepted). The map provides a simplified global overview and some smaller " 
-                "nations and territories are currently not shown."
+                f"The map shows the pairwise vote agreement between {country1_name} and other countries."
+                "An agreement score of 1 (dark blue) means that two countries voted the same on all "
+                "General Assembly (GA) resolutions. A score of 0 (dark red) means that two countries "
+                'always voted in opposite ways ("yes" vs. "no"). The data only covers GA resolutions '
+                "that were successfully passed. The map provides a simplified, static overview of "
+                "political geography. Some smaller nations and territories are not shown and the  "
+                "map does not reflect historical border changes over time."
             ],
             style={
                 "maxWidth": "100%",


### PR DESCRIPTION
* Switch colourbar from Red-White-Blue to Red-Yellow-Blue. Purpose: Make sure that an agreement score of 0.5 is not white (but yellow), thereby distinguishing such scores from the white used for oceans.
* Update feature caption ("Details") to say that the world map is static, and hence does not reflect historical border changes.