### PR TITLE
Speed-up calculation of agreement matrices

### DIFF
--- a/app/un_data_stream/data/processor.py
+++ b/app/un_data_stream/data/processor.py
@@ -147,11 +147,16 @@ class DataProcessor:
       self.logger.info(f"Calculated {len(agreement_matrices)} agreement matrices in {elapsed_time:.2f}s")
       
       return agreement_matrices, country_columns
-    
-    def _calculate_single_resolution_matrix(self, resolution_row: pd.Series, 
-                                        country_columns: List[str]) -> np.ndarray:
+
+    @staticmethod
+    def _calculate_single_resolution_matrix(
+            resolution_row: pd.Series,
+            country_columns: List[str]
+    ) -> np.ndarray:
       """
-      Calculate agreement matrix for a single resolution.
+      Quickly calculate the agreement matrix for a single resolution.
+
+      Uses vectorized calculation via NumPy broadcasting.
       
       Args:
           resolution_row: Series containing votes for all countries
@@ -160,26 +165,20 @@ class DataProcessor:
       Returns:
           np.ndarray: 2D agreement matrix (n_countries x n_countries)
       """
-      n_countries = len(country_columns)
-      agreement_matrix = np.full((n_countries, n_countries), np.nan)
-      
-      # Vote mapping: Y=1, A=0, N=-1, others=NaN
-      vote_mapping = {"Y": 1, "A": 0, "N": -1}
-      
-      # Convert votes to numeric values
-      votes = np.array([vote_mapping.get(resolution_row[country], np.nan) 
-                      for country in country_columns])
-      
-      # Calculate pairwise agreements
-      for i in range(n_countries):
-          for j in range(i, n_countries):
-            if i == j:
-              agreement_matrix[i, j] = 1.0
-            elif not (np.isnan(votes[i]) or np.isnan(votes[j])):
-              diff = abs(votes[i] - votes[j])
-              score = 1.0 - (diff / 2.0)
-              agreement_matrix[i, j] = score
-              agreement_matrix[j, i] = score  # Ensure symmetry
-            # else: leave as NaN for missing votes
+      # 1. Map votes to numeric values
+      vote_mapping = {"Y": 1.0, "A": 0.0, "N": -1.0}
+
+      # Extract the country votes as a NumPy array (floats to accommodate NaN)
+      # Using .get() for safety, defaulting to np.nan
+      votes = np.array([vote_mapping.get(resolution_row[c], np.nan) for c in country_columns])
+
+      # 2. Use broadcasting to compute all pairwise absolute differences
+      # votes[:, np.newaxis] creates a column vector (N, 1)
+      # votes[np.newaxis, :] creates a row vector (1, N)
+      # The subtraction results in an (N, N) matrix of all combinations
+      abs_diff_mat = np.abs(votes[:, np.newaxis] - votes[np.newaxis, :])
+
+      # 3. Apply the agreement-score formula to the entire matrix at once
+      agreement_matrix = 1.0 - (abs_diff_mat / 2.0)
 
       return agreement_matrix

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 import socket
+import pandas as pd
+import numpy as np
 
 def is_internet_available(host="8.8.8.8", port=53, timeout=3):
     """
@@ -20,8 +22,50 @@ def pytest_configure(config):
 def pytest_collection_modifyitems(config, items):
     if is_internet_available():
         return
-    
+
     skip_internet = pytest.mark.skip(reason="No internet connection available")
     for item in items:
         if "needs_internet" in item.keywords:
             item.add_marker(skip_internet)
+
+
+@pytest.fixture(scope="module")
+def random_un_votes_dataframe():
+    """Generates a synthetic, pseudo-random DataFrame mimicking UN voting records."""
+    np.random.seed(1946)
+
+    n_countries = 193
+    n_resolutions = 1_000
+
+    countries = [f"Member_State_{i}" for i in range(n_countries)]
+    undl_ids = [f"A/RES/78/{i}" for i in range(n_resolutions)]
+
+    data = {
+        'undl_id': undl_ids,
+        'date': pd.date_range(start='2024-01-01', periods=n_resolutions),
+        'title': [f"Resolution Topic {i}" for i in range(n_resolutions)]
+    }
+
+    # Fill country columns with random Y, N, A, or NaN (Missing)
+    for country in countries:
+        data[country] = np.random.choice(['Y', 'N', 'A', np.nan], n_resolutions, p=[0.4, 0.2, 0.3, 0.1])
+
+    return pd.DataFrame(data)
+
+
+@pytest.fixture
+def data_processor(caplog):
+    """
+    Provides an initialized DataProcessor instance.
+    The 'caplog' fixture is included to allow testing of log output.
+    """
+    import logging
+    from app.un_data_stream.data.processor import DataProcessor
+
+    # Using a dedicated test logger to avoid polluting main logs
+    logger = logging.getLogger("un_data_test")
+    config = {
+        "env": "test",
+        "threshold": 0.5
+    }
+    return DataProcessor(config, logger)

--- a/tests/unit/test_agreement_calculation.py
+++ b/tests/unit/test_agreement_calculation.py
@@ -1,0 +1,46 @@
+import pytest
+import time
+import pandas as pd
+import numpy as np
+
+
+def test_calculate_single_resolution_matrix_correctness(data_processor):
+    """Verify correctness of the agreement-score computation, including NaN handling."""
+
+    country_cols = 'Country_A Country_B Country_C Country_D Country_E Country_F'.split(' ')
+    # A: Yes, B: Abstain, C: No, D: Missing
+    row = pd.Series({
+        'undl_id': 'RES/1',
+        'Country_A': 'Y',
+        'Country_B': 'A',
+        'Country_C': 'N',
+        'Country_D': '?',  # Invalid/Missing
+        'Country_E': 'Y',
+        'Country_F': 'N'
+    })
+
+    matrix = data_processor._calculate_single_resolution_matrix(row, country_cols)
+
+    assert matrix[0, 0] == 1.0  # Self-agreement
+    assert matrix[0, 4] == 1.0  # Y vs Y
+    assert matrix[2, 5] == 1.0  # N vs N
+    assert matrix[0, 1] == 0.5  # Y vs A
+    assert matrix[0, 2] == 0.0  # Y vs N
+    assert matrix[1, 2] == 0.5  # A vs N
+    assert np.isnan(matrix[0, 3])  # Y vs NaN
+    assert np.isnan(matrix[1, 3])  # A vs NaN
+    assert np.isnan(matrix[2, 3])  # N vs NaN
+
+
+def test_calculate_agreement_matrix_performance(data_processor, random_un_votes_dataframe):
+    """
+    Test the compute-time performance of the agreement-matrix calculation
+    using the shared fixture.
+    """
+    start = time.perf_counter()
+    matrices, countries = data_processor.calculate_agreement_matrix(random_un_votes_dataframe)
+    end = time.perf_counter()
+
+    assert len(matrices) == len(random_un_votes_dataframe)
+    assert len(countries) == 193
+    print(f"\nExecution time for {len(random_un_votes_dataframe)} resolutions: {end - start:.4f}s")


### PR DESCRIPTION
- Vectorise the computation in `DataProcessor._calculate_single_resolution_matrix` to avoid a nested for-loop.
- Add unit tests to check correctness and performance of the calculation. (Performance test: Using a synthetic data-frame with votes for ~200 countries and 1'000 resolutions, the speed-up on my machine was around x60.)