### PR TITLE
Support experimental deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - develop
+      - stable
 
 env:
   REGISTRY: ghcr.io
@@ -39,7 +39,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=
-            type=ref,prefix=branch-,ref=refs/heads/*
+            type=raw,value=stable,enable={{startsWith(github.ref, 'refs/heads/stable')}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
 
 env:
   REGISTRY: ghcr.io
@@ -38,6 +39,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=
+            type=ref,prefix=branch-,ref=refs/heads/*
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,4 +46,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
           no-cache: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,15 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+# To be set by the CI
+ARG BUILD_COMMIT=unknown
+ARG BUILD_DATE=unknown
+ENV BUILD_COMMIT=${BUILD_COMMIT} \
+    BUILD_DATE=${BUILD_DATE}
+
+# Set to True at runtime if we want to show that it's experimental
+ENV WARN_EXPERIMENTAL=False
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,10 +1,6 @@
 import dash
 from dash import dcc, html
 
-from .features import navbar
-from .features import footer
-from .features import breadcrumb
-
 external_scripts = [
     {
         "src": "https://unst-dev2.vsos.ethz.ch/api/script.js",
@@ -18,9 +14,16 @@ app = dash.Dash(
     use_pages=True,
     suppress_callback_exceptions=True,
     external_scripts=external_scripts,
+    # Base path may be set via DASH_URL_BASE_PATHNAME env variable
 )
 
 server = app.server
+
+# Features must be imported after app is initialized, so they can use
+# get_relative_path to resolve links based on the app's base path.
+from .features import navbar  # noqa: E402
+from .features import footer  # noqa: E402
+from .features import breadcrumb  # noqa: E402
 
 app.layout = html.Div(
     [

--- a/app/assets/footer.css
+++ b/app/assets/footer.css
@@ -25,6 +25,11 @@
   opacity: 0.78;
 }
 
+.footer-build-info {
+  opacity: 0.5;
+  font-size: 0.875rem;
+}
+
 .footer-column {
   display: flex;
   flex-direction: column;

--- a/app/assets/navbar.css
+++ b/app/assets/navbar.css
@@ -32,3 +32,13 @@
     }
   }
 }
+
+
+.navbar-experimental {
+  h1 {
+    span {
+      color: #e7ce41;
+      font-size: 0.8rem;
+    }
+  }
+}

--- a/app/assets/navbar.css
+++ b/app/assets/navbar.css
@@ -37,8 +37,22 @@
 .navbar-experimental {
   h1 {
     span {
-      color: #e7ce41;
+      color: #ecb92d;
       font-size: 0.8rem;
     }
+  }
+
+  position: relative;
+
+  /** show construction-like indicator on right edge with gradients */
+  &::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    width: 10px;
+    background: linear-gradient(45deg, transparent 25%, #ecb92d 25%, #ecb92d 50%, transparent 50%, transparent 75%, #ecb92d 75%, #ecb92d);
+    background-size: 10px 10px;
   }
 }

--- a/app/features/case_study.py
+++ b/app/features/case_study.py
@@ -1,4 +1,4 @@
-from dash import html, dcc
+from dash import get_relative_path, html, dcc
 
 
 _share_step = lambda n: html.Div([
@@ -21,7 +21,7 @@ _tip = html.P(
     [
         html.Em("Tip: "),
         "We recommend opening the ",
-        dcc.Link("Trends page", href="/trends"),
+        dcc.Link("Trends page", href=get_relative_path("/trends")),
         " in a separate tab so you can follow along step by step without losing your place.",
     ],
     style={"fontStyle": "italic", "color": "#666"},
@@ -55,7 +55,7 @@ layout = html.Div(
                                 html.P(
                                     [
                                         "Head to the ",
-                                        dcc.Link("Trends page", href="/trends"),
+                                        dcc.Link("Trends page", href=get_relative_path("/trends")),
                                         ". This is where all the analysis tools live. "
                                         "You'll see a filter panel at the top and a set of tabs below it, let's walk through them.",
                                     ]
@@ -198,7 +198,7 @@ layout = html.Div(
                                 html.P(
                                     [
                                         "Head to the ",
-                                        dcc.Link("Trends page", href="/trends"),
+                                        dcc.Link("Trends page", href=get_relative_path("/trends")),
                                         ". Set ",
                                         html.Strong("Bulgaria"),
                                         " as the main country and ",

--- a/app/features/footer.py
+++ b/app/features/footer.py
@@ -1,5 +1,13 @@
 from dash import html
 
+import os
+
+build_commit = os.getenv("BUILD_COMMIT", "unknown")
+build_date = os.getenv("BUILD_DATE", "unknown")
+if build_date != "unknown":
+    # GitHub provides with full ISO 8601 format, keep only date part
+    build_date = build_date.split("T")[0]
+
 layout = html.Footer(
     html.Div(
         [
@@ -11,6 +19,12 @@ layout = html.Footer(
                         "in collaboration with the UN Dag Hammarskjöld Library.",
                         className="footer-subtitle",
                     ),
+                    html.Span(
+                        "Commit {} - {}".format(build_commit, build_date),
+                        className="footer-build-info",
+                    )
+                    if build_commit != "unknown" and build_date != "unknown"
+                    else None,
                 ],
                 className="footer-column",
             ),

--- a/app/features/navbar.py
+++ b/app/features/navbar.py
@@ -2,7 +2,9 @@ from dash import get_relative_path, html, dcc
 
 import os
 
-experimental = os.getenv("WARN_EXPERIMENTAL", "True") == "True"
+# At runtime, set this env variable to True if you want to show indicators
+# that the web page is experimental (e.g. to distinguish from a stable version).
+experimental = os.getenv("WARN_EXPERIMENTAL", "True") == "False"
 
 layout = (
     html.Header(

--- a/app/features/navbar.py
+++ b/app/features/navbar.py
@@ -1,9 +1,9 @@
-from dash import html, dcc
+from dash import get_relative_path, html, dcc
 
 layout = (
     html.Header(
         [
-            html.H1(html.Div(id="navbar-home-click", children=dcc.Link("UN-ETH Policy Pulse", href="/"))),
+            html.H1(html.Div(id="navbar-home-click", children=dcc.Link("UN-ETH Policy Pulse", href=get_relative_path("/")))),
             html.Div(),
         ],
         className="navbar",

--- a/app/features/navbar.py
+++ b/app/features/navbar.py
@@ -1,11 +1,25 @@
 from dash import get_relative_path, html, dcc
 
+import os
+
+experimental = os.getenv("WARN_EXPERIMENTAL", "True") == "True"
+
 layout = (
     html.Header(
         [
-            html.H1(html.Div(id="navbar-home-click", children=dcc.Link("UN-ETH Policy Pulse", href=get_relative_path("/")))),
+            html.H1(
+                html.Div(
+                    id="navbar-home-click",
+                    children=[
+                        dcc.Link("UN-ETH Policy Pulse", href=get_relative_path("/")),
+                        html.Span(" Experimental Branch; Unstable!")
+                        if experimental
+                        else None,
+                    ],
+                )
+            ),
             html.Div(),
         ],
-        className="navbar",
+        className=f"navbar {'navbar-experimental' if experimental else ''}",
     ),
 )

--- a/app/features/wordcloud_viz.py
+++ b/app/features/wordcloud_viz.py
@@ -1,4 +1,4 @@
-from dash import html
+from dash import get_relative_path, html
 
 
 def register_callbacks():
@@ -7,6 +7,6 @@ def register_callbacks():
 
 layout = html.Div(
     [
-        html.Img(src="/assets/wordcloud.png", width="100%"),
+        html.Img(src=get_relative_path("/assets/wordcloud.png"), width="100%"),
     ]
 )

--- a/app/pages/index_page.py
+++ b/app/pages/index_page.py
@@ -1,4 +1,4 @@
-from dash import html, dcc, register_page
+from dash import get_relative_path, html, dcc, register_page
 
 from ..features import (
     feature_description,
@@ -32,7 +32,7 @@ layout = html.Div(
                     [
                         dcc.Link(
                             "Explore Data →",
-                            href="/trends",
+                            href=get_relative_path("/trends"),
                             className="cta-button",
                         ),
                         html.A(

--- a/app/pages/index_page.py
+++ b/app/pages/index_page.py
@@ -46,7 +46,7 @@ layout = html.Div(
                 html.Div(
                     [
                         html.Img(
-                            src="/assets/main.webp",
+                            src=get_relative_path("/assets/main.webp"),
                             className="main-header-image",
                         ),
                     ],


### PR DESCRIPTION
Relative links resolved wrongly when the app was deployed to a non-root URL (like `/nightly`). Additionally, there was a lack of indication that the nightly deployment was in fact, experimental. This PR resolves the issues.

- CI now builds `stable` and `latest` images from respective branches
  - `stable` is the one that powers the main page (used for feedback collection from UN DHL etc)
  - `latest` is for experimental development
- Footer and navbar can be configured at runtime to show whether a deployment is unstable or not

<img width="633" height="89" alt="msedge_2026-05-15_03-36-24" src="https://github.com/user-attachments/assets/688da0a1-12ae-4337-8bc4-dae0ed245165" />

- All `href` links and material should use the `get_relative_path()` wrapper instead of directly using values. The function prepends whatever path the app is deployed at.