### PR TITLE
Halve memory usage and reduce cache filesize by 99%

### DIFF
--- a/app/un_data_stream/data/processor.py
+++ b/app/un_data_stream/data/processor.py
@@ -157,20 +157,21 @@ class DataProcessor:
       Quickly calculate the agreement matrix for a single resolution.
 
       Uses vectorized calculation via NumPy broadcasting.
+      Stores matrices as float32 to reduce memory by 50% compared to float64.
       
       Args:
           resolution_row: Series containing votes for all countries
           country_columns: List of country column names
       
       Returns:
-          np.ndarray: 2D agreement matrix (n_countries x n_countries)
+          np.ndarray: 2D agreement matrix (n_countries x n_countries) as float32
       """
-      # 1. Map votes to numeric values
-      vote_mapping = {"Y": 1.0, "A": 0.0, "N": -1.0}
+      # 1. Map votes to numeric values using float32 for memory efficiency
+      vote_mapping = {"Y": np.float32(1.0), "A": np.float32(0.0), "N": np.float32(-1.0)}
 
-      # Extract the country votes as a NumPy array (floats to accommodate NaN)
+      # Extract the country votes as a NumPy array (float32 to reduce memory footprint)
       # Using .get() for safety, defaulting to np.nan
-      votes = np.array([vote_mapping.get(resolution_row[c], np.nan) for c in country_columns])
+      votes = np.array([vote_mapping.get(resolution_row[c], np.nan) for c in country_columns], dtype=np.float32)
 
       # 2. Use broadcasting to compute all pairwise absolute differences
       # votes[:, np.newaxis] creates a column vector (N, 1)
@@ -179,6 +180,6 @@ class DataProcessor:
       abs_diff_mat = np.abs(votes[:, np.newaxis] - votes[np.newaxis, :])
 
       # 3. Apply the agreement-score formula to the entire matrix at once
-      agreement_matrix = 1.0 - (abs_diff_mat / 2.0)
+      agreement_matrix = (np.float32(1.0) - (abs_diff_mat / np.float32(2.0))).astype(np.float32)
 
       return agreement_matrix

--- a/app/un_data_stream/data/repository.py
+++ b/app/un_data_stream/data/repository.py
@@ -41,28 +41,41 @@ class DataRepository:
 
         self.logger.info("Initializing UNDataRepository")
 
-        # Check if data is already processed and available
-        if self._has_cached_data():
-            # Version Check
-            if self._check_data_version():
-                # Cached data found and version matches -> load
-                self._load_cached_data()
-                self.logger.info("Initialization complete with cached data.")
-                return
-            else:
-                self.logger.info("Data version mismatch or missing. Rebuilding data...")
+        if not self._has_cached_data() or not self._check_data_version():
+            self.logger.info("Initializing from raw data sources.")
+            # Check if configured data sources are valid
+            if not self._resolve_and_validate_data_urls():
+                self.logger.error(
+                    "One or more configured data sources are invalid. "
+                    "Please review settings in data_sources.yaml."
+                )
+                raise ValueError("Failed to resolve one or more data sources. Check logs for details.")
 
-        # Check if configured data sources are valid
-        if not self._resolve_and_validate_data_urls():
-            self.logger.error(
-                "One or more configured data sources are invalid. "
-                "Please review settings in data_sources.yaml."
-            )
-            raise ValueError("Failed to resolve one or more data sources. Check logs for details.")
+            self._build_data()
+        else:
+            # Cached data found and version matches -> load
+            self.logger.info("Initializing from cached data.")
+            self._load_cached_data()
 
-        self._build_data()
-
-        self.logger.info("Initialization complete with fetched data.")
+        self.logger.info("Initialization complete. Below are memory footprints:")
+        self.logger.info(
+            f"Resolution Table: {self.resolution_table.memory_usage(index=True).sum() / (1024**2):.2f} MB"
+        )
+        self.logger.info(
+            f"Resolution Subject Table: {self.resolution_subject_table.memory_usage(index=True).sum() / (1024**2):.2f} MB"
+        )
+        self.logger.info(
+            f"Subject Table: {self.subject_table.memory_usage(index=True).sum() / (1024**2):.2f} MB"
+        )
+        self.logger.info(
+            f"Closure Table: {self.closure_table.memory_usage(index=True).sum() / (1024**2):.2f} MB"
+        )
+        self.logger.info(
+            f"Broader Table: {self.broader_table.memory_usage(index=True).sum() / (1024**2):.2f} MB"
+        )
+        self.logger.info(
+            f"Agreement Matrices: {sum(map(lambda x: x[1].nbytes / (1024**2), self.agreement_matrices.items()))} MB"
+        )
 
     def get_data(self) -> Dict[str, Any]:
         """Return processed data as a dictionary of DataFrames."""

--- a/app/un_data_stream/data/repository.py
+++ b/app/un_data_stream/data/repository.py
@@ -5,6 +5,7 @@ This module handles storage, retrieval, and caching of processed UN data,
 orchestrating the entire data processing pipeline.
 """
 
+import bz2
 import json
 import logging
 import pickle
@@ -216,19 +217,34 @@ class DataRepository:
         data_path.mkdir(exist_ok=True)
 
         # Load CSV files
+        print("Loading resolution table")
         self.resolution_table = pd.read_csv(data_path / 'resolution_table.csv')
-        self.resolution_subject_table = pd.read_csv(data_path / 'resolution_subject_table.csv')
-        self.subject_table = pd.read_csv(data_path / 'subject_table.csv')
-        self.closure_table = pd.read_csv(data_path / 'closure_table.csv')
-        self.broader_table = pd.read_csv(data_path / 'broader_table.csv')
+        print("Loading resolution subject table")
+        self.resolution_subject_table = pd.read_csv(
+            data_path / "resolution_subject_table.csv"
+        )
+        print("Loading subject table")
+        self.subject_table = pd.read_csv(data_path / "subject_table.csv")
+        print("Loading closure table")
+        self.closure_table = pd.read_csv(data_path / "closure_table.csv")
+        print("Loading broader table")
+        self.broader_table = pd.read_csv(data_path / "broader_table.csv")
+
+        # Load pickle file containing agreement matrices and labels
+        pkl_path = data_path / 'agreement_matrices.pkl'
+        try:
+            # Try loading with compression first
+            with bz2.BZ2File(pkl_path, 'rb') as f:
+                agreement_data = pickle.load(f)
+        except (EOFError, OSError):
+            # Fall back to uncompressed pickle for backward compatibility
+            with open(pkl_path, 'rb') as f:
+                agreement_data = pickle.load(f)
+
+        self.agreement_matrices = agreement_data["agreement_matrices"]
+        self.country_columns = agreement_data["country_columns"]
+
         self.logger.info("Cached data loaded successfully.")
-
-        # Load agreement matrices
-        with open(data_path / 'agreement_matrices.pkl', 'rb') as f:
-            agreement_data = pickle.load(f)
-
-        self.agreement_matrices = agreement_data['agreement_matrices']
-        self.country_columns = agreement_data['country_columns']
     
     def _save_cached_data(self):
         """Save data files into DataFrames."""
@@ -242,7 +258,9 @@ class DataRepository:
         self.closure_table.to_csv(data_path / 'closure_table.csv', index=False)
         self.broader_table.to_csv(data_path / 'broader_table.csv', index=False)
 
-        with open(data_path / 'agreement_matrices.pkl', 'wb') as f:
+        pkl_path = data_path / 'agreement_matrices.pkl'
+        # Save agreement matrices with bz2 compression to reduce disk space
+        with bz2.BZ2File(pkl_path, 'wb') as f:
             agreement_data = {
                 'agreement_matrices': self.agreement_matrices,
                 'country_columns': self.country_columns

--- a/app/un_data_stream/data/repository.py
+++ b/app/un_data_stream/data/repository.py
@@ -243,6 +243,7 @@ class DataRepository:
         self.logger.info("Loading broader table")
         self.broader_table = pd.read_csv(data_path / "broader_table.csv")
 
+        self.logger.info("Loading agreement matrices")
         # Load pickle file containing agreement matrices and labels
         pkl_path = data_path / 'agreement_matrices.pkl'
         try:
@@ -250,9 +251,19 @@ class DataRepository:
             with bz2.BZ2File(pkl_path, 'rb') as f:
                 agreement_data = pickle.load(f)
         except (EOFError, OSError):
-            # Fall back to uncompressed pickle for backward compatibility
             with open(pkl_path, 'rb') as f:
                 agreement_data = pickle.load(f)
+
+            self.logger.warning("Cache is in old format. Rewriting...")
+            # If it uses float64, convert to float32
+            for key in agreement_data["agreement_matrices"]:
+                agreement_data["agreement_matrices"][key] = agreement_data[
+                    "agreement_matrices"
+                ][key].astype("float32")
+
+            # Write back new cache in compressed format
+            with bz2.BZ2File(pkl_path, "wb") as f:
+                pickle.dump(agreement_data, f)
 
         self.agreement_matrices = agreement_data["agreement_matrices"]
         self.country_columns = agreement_data["country_columns"]

--- a/app/un_data_stream/data/repository.py
+++ b/app/un_data_stream/data/repository.py
@@ -230,17 +230,17 @@ class DataRepository:
         data_path.mkdir(exist_ok=True)
 
         # Load CSV files
-        print("Loading resolution table")
+        self.logger.info("Loading resolution table")
         self.resolution_table = pd.read_csv(data_path / 'resolution_table.csv')
-        print("Loading resolution subject table")
+        self.logger.info("Loading resolution subject table")
         self.resolution_subject_table = pd.read_csv(
             data_path / "resolution_subject_table.csv"
         )
-        print("Loading subject table")
+        self.logger.info("Loading subject table")
         self.subject_table = pd.read_csv(data_path / "subject_table.csv")
-        print("Loading closure table")
+        self.logger.info("Loading closure table")
         self.closure_table = pd.read_csv(data_path / "closure_table.csv")
-        print("Loading broader table")
+        self.logger.info("Loading broader table")
         self.broader_table = pd.read_csv(data_path / "broader_table.csv")
 
         # Load pickle file containing agreement matrices and labels


### PR DESCRIPTION
This change will have to be applied to both `main` and `stable` branches.

Since the `main` (experimental) branch will see a lot of changes when #30 is merged, I've left that for later. This PR directly merges the changes to the `stable` branch that powers the version UN-DHL/users see.

The change does two things:
- Use float32 instead of float64 (default) to use half the amount of bits for pairwise alignment/agreement scores
  - This loses some precision but that level of precision hasn't been needed in this app anyway
  - This cuts runtime memory usage by 800 MB
- Use bz2 compression for the cache file
  - This brings down the cache file (both for new and existing caches) from 1.8 Gb to 2 Mb.